### PR TITLE
Radical Image Loading Fix, Typos, Etc

### DIFF
--- a/src/components/AdvancedAssignmentSettings/AdvancedAssignmentSettings.tsx
+++ b/src/components/AdvancedAssignmentSettings/AdvancedAssignmentSettings.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Assignment, AssignmentType } from "../../types/Assignment";
 import { AssignmentTypeName } from "../AssignmentTypeSelector/AssignmentTypeSelector.types";
 import { BackToBackChoice } from "../BackToBackOption/BackToBackOption.types";
+import { AssignmentSessionType } from "../../types/AssignmentQueueTypes";
 import Card from "../Card";
 import AssignmentSelector from "../AssignmentSelector";
 import AdvancedAssignmentFilters from "../AdvancedAssignmentFilters";
@@ -17,6 +18,7 @@ type Props = {
   showBackToBackOption: boolean;
   backToBackChoice: BackToBackChoice;
   setBackToBackChoice: (choice: BackToBackChoice) => void;
+  settingsType: AssignmentSessionType;
 };
 
 function AdvancedAssignmentSettings({
@@ -29,6 +31,7 @@ function AdvancedAssignmentSettings({
   showBackToBackOption,
   backToBackChoice,
   setBackToBackChoice,
+  settingsType,
 }: Props) {
   const [selectedAssignmentTypes, setSelectedAssignmentTypes] = useState(
     availableAssignmentTypes
@@ -58,6 +61,7 @@ function AdvancedAssignmentSettings({
         assignmentData={assignmentData}
         filterByCurrentLevel={filterByCurrentLevel}
         assignmentTypeFilter={selectedAssignmentTypes}
+        settingsType={settingsType}
       ></AssignmentSelector>
     </Card>
   );

--- a/src/components/AssignmentSelector/AssignmentSelector.tsx
+++ b/src/components/AssignmentSelector/AssignmentSelector.tsx
@@ -20,6 +20,7 @@ import {
   SubjectType,
   Vocabulary,
 } from "../../types/Subject";
+import { AssignmentSessionType } from "../../types/AssignmentQueueTypes";
 import SubjectChars from "../SubjectChars";
 import { RadicalMeaning, ReadingAndMeaning } from "../SubjectWideBtnList";
 import Button from "../Button";
@@ -90,10 +91,6 @@ const LvlBubble = styled.p`
   border: 1px solid white;
 `;
 
-const NoAssignmentsTxt = styled.p`
-  margin: 16px;
-`;
-
 const SelectedInfoContainer = styled.div`
   display: flex;
   align-items: center;
@@ -148,14 +145,14 @@ const LogoContainer = styled(AbsoluteCenterContainer)`
   text-align: center;
   z-index: 5;
 
-  h5 {
-    margin: 0 0 25px 0;
-    width: 100%;
-  }
-
   img {
     height: 250px;
   }
+`;
+
+const LogoContainerHeading = styled.h5`
+  margin: 0 0 25px 0;
+  width: 100%;
 `;
 
 type Props = {
@@ -163,6 +160,7 @@ type Props = {
   selectedAdvancedSubjIDs: string[];
   setSelectedAdvancedSubjIDs: React.Dispatch<React.SetStateAction<string[]>>;
   filterByCurrentLevel: boolean;
+  settingsType: AssignmentSessionType;
   assignmentTypeFilter?: AssignmentType[];
   showMeaning?: boolean;
 };
@@ -173,8 +171,9 @@ function AssignmentSelector({
   assignmentData,
   selectedAdvancedSubjIDs,
   setSelectedAdvancedSubjIDs,
-  assignmentTypeFilter,
   filterByCurrentLevel,
+  settingsType,
+  assignmentTypeFilter,
   showMeaning = true,
 }: Props) {
   const [availableSubjects, setAvailableSubjects] = useState<Subject[]>([]);
@@ -223,15 +222,12 @@ function AssignmentSelector({
     <>
       {availableSubjects ? (
         availableSubjects.length === 0 ? (
-          // <NoAssignmentsTxt>
-          //   Hmm, looks like we can't find any assignments using those filters...
-          // </NoAssignmentsTxt>
           <NoAssignmentsContainer>
             <LogoContainer>
-              <h5>
-                Hmm, looks like we can't find any assignments using those
+              <LogoContainerHeading>
+                Hmm, looks like we can't find any {settingsType}s using those
                 filters...
-              </h5>
+              </LogoContainerHeading>
               <img src={LogoExclamation} />
             </LogoContainer>
           </NoAssignmentsContainer>

--- a/src/components/AssignmentSelector/AssignmentSelector.tsx
+++ b/src/components/AssignmentSelector/AssignmentSelector.tsx
@@ -27,6 +27,8 @@ import Counter from "../Counter";
 import CheckCircleIcon from "../../images/check-in-circle.svg";
 import RemoveIcon from "../../images/close.svg";
 import CheckIcon from "../../images/checkmark.svg";
+import LogoExclamation from "../../images/logo-exclamation.svg";
+import { AbsoluteCenterContainer } from "../../styles/BaseStyledComponents";
 import styled from "styled-components";
 
 const SubjectList = styled(ToggleGroup.Root)`
@@ -129,6 +131,33 @@ const SelectDeselectIcon = styled(IonIcon)`
   height: 1.5em;
 `;
 
+const NoAssignmentsContainer = styled.div`
+  position: relative;
+  width: 100%;
+  z-index: 5;
+  min-height: 350px;
+  margin-bottom: 70px;
+`;
+
+const LogoContainer = styled(AbsoluteCenterContainer)`
+  width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  padding: 0 16px;
+  text-align: center;
+  z-index: 5;
+
+  h5 {
+    margin: 0 0 25px 0;
+    width: 100%;
+  }
+
+  img {
+    height: 250px;
+  }
+`;
+
 type Props = {
   assignmentData: Assignment[];
   selectedAdvancedSubjIDs: string[];
@@ -194,9 +223,18 @@ function AssignmentSelector({
     <>
       {availableSubjects ? (
         availableSubjects.length === 0 ? (
-          <NoAssignmentsTxt>
-            Hmm, looks like we can't find any assignments using those filters...
-          </NoAssignmentsTxt>
+          // <NoAssignmentsTxt>
+          //   Hmm, looks like we can't find any assignments using those filters...
+          // </NoAssignmentsTxt>
+          <NoAssignmentsContainer>
+            <LogoContainer>
+              <h5>
+                Hmm, looks like we can't find any assignments using those
+                filters...
+              </h5>
+              <img src={LogoExclamation} />
+            </LogoContainer>
+          </NoAssignmentsContainer>
         ) : (
           <>
             <SelectedInfoContainer>

--- a/src/components/AssignmentSelector/AssignmentSelector.tsx
+++ b/src/components/AssignmentSelector/AssignmentSelector.tsx
@@ -7,6 +7,7 @@ import {
   filterSubjectsByLevel,
   filterSubjectsByType,
   getSubjectColor,
+  sortBySubjectTypeAndLevel,
 } from "../../services/SubjectAndAssignmentService";
 import { useUserInfoStore } from "../../stores/useUserInfoStore";
 import { useSubjectsByIDs } from "../../hooks/useSubjectsByIDs";
@@ -127,27 +128,6 @@ const SelectDeselectIcon = styled(IonIcon)`
   width: 1.5em;
   height: 1.5em;
 `;
-
-// TODO: move this to more general file
-const sortBySubjectTypeAndLevel = (subjArr: Subject[]): Subject[] => {
-  const subjectOrder: SubjectType[] = [
-    "radical",
-    "kanji",
-    "vocabulary",
-    "kana_vocabulary",
-  ];
-
-  return subjArr.sort((subjA, subjB) => {
-    const indexA = subjectOrder.indexOf(subjA.object);
-    const indexB = subjectOrder.indexOf(subjB.object);
-    if (indexA !== indexB) {
-      return indexA - indexB;
-    }
-
-    // if same subject type, sort by level
-    return subjA.level - subjB.level;
-  });
-};
 
 type Props = {
   assignmentData: Assignment[];

--- a/src/components/AssignmentSettings/AssignmentSettings.tsx
+++ b/src/components/AssignmentSettings/AssignmentSettings.tsx
@@ -239,6 +239,7 @@ function AssignmentSettings({
                     showBackToBackOption={settingsType === "review"}
                     backToBackChoice={backToBackChoice}
                     setBackToBackChoice={setBackToBackChoice}
+                    settingsType={settingsType}
                   />
                 ),
               },

--- a/src/components/BackToBackOption/BackToBackOption.tsx
+++ b/src/components/BackToBackOption/BackToBackOption.tsx
@@ -27,7 +27,7 @@ function BackToBackOption({
   return (
     <>
       <Label
-        labelText="Batch to Back"
+        labelText="Back to Back"
         idOfControl={labelId}
         labelfontSize={headingSize}
       />

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -14,7 +14,6 @@ import LogoExclamation from "../images/logo-exclamation.svg";
 import {
   AbsoluteCenterContainer,
   ContentWithTabBar,
-  FixedCenterContainer,
 } from "../styles/BaseStyledComponents";
 import styled from "styled-components";
 import { AnimatePresence, motion } from "framer-motion";

--- a/src/services/ImageSrcService.ts
+++ b/src/services/ImageSrcService.ts
@@ -17,21 +17,17 @@ import lessonsBgImg499 from "../images/bg_lessons_250-499.png";
 import lessonsBgImg500 from "../images/bg_lessons_500+.png";
 import { Subject, SubjectCharacterImage } from "../types/Subject";
 
-// preferring svg images
+// preferring png images, svg never seems to work so always uses fallback
 const sortCharacterImages = (
   imgA: SubjectCharacterImage,
   imgB: SubjectCharacterImage
 ) => {
-  if (
-    imgA.content_type === "image/svg+xml" &&
-    imgB.content_type !== "image/svg+xml"
-  ) {
+  let pngFileType = "image/png";
+
+  if (imgA.content_type === pngFileType && imgB.content_type !== pngFileType) {
     return 1;
   }
-  if (
-    imgA.content_type !== "image/svg+xml" &&
-    imgB.content_type === "image/svg+xml"
-  ) {
+  if (imgA.content_type !== pngFileType && imgB.content_type === pngFileType) {
     return -1;
   }
   return 0;

--- a/src/services/SubjectAndAssignmentService.ts
+++ b/src/services/SubjectAndAssignmentService.ts
@@ -321,3 +321,23 @@ export const sortAssignmentsBySrsStage = (
 export const filterSubjectsByLevel = (subjects: Subject[], level: number) => {
   return subjects.filter((subject) => subject.level === level);
 };
+
+export const sortBySubjectTypeAndLevel = (subjArr: Subject[]): Subject[] => {
+  const subjectOrder: SubjectType[] = [
+    "radical",
+    "kanji",
+    "vocabulary",
+    "kana_vocabulary",
+  ];
+
+  return subjArr.sort((subjA, subjB) => {
+    const indexA = subjectOrder.indexOf(subjA.object);
+    const indexB = subjectOrder.indexOf(subjB.object);
+    if (indexA !== indexB) {
+      return indexA - indexB;
+    }
+
+    // if same subject type, sort by level
+    return subjA.level - subjB.level;
+  });
+};

--- a/src/styles/BaseStyledComponents.tsx
+++ b/src/styles/BaseStyledComponents.tsx
@@ -198,6 +198,7 @@ export const FloatingButtonContainer = styled(
   width: 100%;
   display: flex;
   justify-content: center;
+  z-index: 10;
 `;
 
 export const FullWidthColumn = styled.div`

--- a/src/styles/BaseStyledComponents.tsx
+++ b/src/styles/BaseStyledComponents.tsx
@@ -263,6 +263,7 @@ export const LoadingContainer = styled.div`
 export const SettingOptionContainer = styled.div`
   display: flex;
   justify-content: space-between;
+  gap: 10px;
   margin: 22px 12px;
   align-items: center;
 


### PR DESCRIPTION
- Fixes "batch to back" typo
- Preferring png images over svg for radicals with images, seems like svg rarely or never exists
- Displaying icon with confused crabigator when can't find assignments with certain filters