### PR TITLE
Auxiliary Meanings Accounted for in User Answers, Removal Use of `.at`

### DIFF
--- a/src/components/AssignmentQueueCards/AssignmentQueueCard.tsx
+++ b/src/components/AssignmentQueueCards/AssignmentQueueCard.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import { IonIcon } from "@ionic/react";
 import {
   useMotionValue,
   useTransform,
@@ -17,8 +16,9 @@ import AssignmentCharAndType from "./AssignmentCharAndType";
 import AssignmentAnswerInput from "./AssignmentAnswerInput";
 import ReviewItemBottomSheet from "../ReviewItemBottomSheet";
 import Emoji from "../Emoji";
-import RetryIcon from "../../images/retry.svg";
-import NextIcon from "../../images/next-item.svg";
+import SvgIcon from "../SvgIcon";
+import RetryIcon from "../../images/retry.svg?react";
+import NextIcon from "../../images/next-item.svg?react";
 import {
   NextCardOverlay,
   RetryCardOverlay,
@@ -249,7 +249,7 @@ export const AssignmentQueueCard = ({
             >
               <SwipeIconAndText>
                 <Retry>
-                  <IonIcon icon={RetryIcon}></IonIcon>
+                  <SvgIcon icon={<RetryIcon />} width="85px" height="85px" />
                 </Retry>
                 <RetryTxt>Retry</RetryTxt>
               </SwipeIconAndText>
@@ -261,7 +261,7 @@ export const AssignmentQueueCard = ({
             >
               <SwipeIconAndText>
                 <Next>
-                  <IonIcon icon={NextIcon}></IonIcon>
+                  <SvgIcon icon={<NextIcon />} width="85px" height="85px" />
                 </Next>
                 <NextTxt>Next</NextTxt>
               </SwipeIconAndText>

--- a/src/components/AssignmentQueueCards/AssignmentQueueCards.hooks.ts
+++ b/src/components/AssignmentQueueCards/AssignmentQueueCards.hooks.ts
@@ -14,6 +14,7 @@ import useUserSettingsStoreFacade from "../../stores/useUserSettingsStore/useUse
 import useAssignmentQueueStoreFacade from "../../stores/useAssignmentQueueStore/useAssignmentQueueStore.facade";
 import { AssignmentQueueItem } from "../../types/AssignmentQueueTypes";
 
+// TODO: refactor this, kinda a mess
 export const useAssignmentQueue = () => {
   const {
     showPopoverMsg,

--- a/src/components/AssignmentQueueCards/AssignmentQueueCards.test.tsx
+++ b/src/components/AssignmentQueueCards/AssignmentQueueCards.test.tsx
@@ -139,6 +139,10 @@ test.todo("Correct answer is marked as correct", () => {
   const { user } = renderComponent(callbackParams, componentProps.currPath);
 });
 
+test.todo(
+  "Warning toast is displayed when user enters a forbidden meaning answer"
+);
+
 const renderComponent = (
   props: CardProps,
   currPath: "/reviews/session" | "/lessons/quiz"

--- a/src/components/AssignmentQueueCards/AssignmentQueueCards.test.tsx
+++ b/src/components/AssignmentQueueCards/AssignmentQueueCards.test.tsx
@@ -1,28 +1,152 @@
+import { HttpResponse, http } from "msw";
+import { faker } from "@faker-js/faker";
+import { assignmentsEndpoint, reviewsEndpoint } from "../../testing/endpoints";
+import { server } from "../../testing/mocks/server";
+import { generateRandomQueueItems } from "../../testing/mocks/data-generators/assignmentQueueGenerator";
+import { act, renderHook, renderWithRouter } from "../../testing/test-utils";
+import {
+  createCorrespondingSubject,
+  generatePreFlattenedAssignment,
+} from "../../testing/mocks/data-generators/assignmentGenerator";
+import { fakeReviewUpdatedResponse } from "../../testing/mocks/data-generators/reviewGenerator";
+import { useAssignmentQueueStore } from "../../stores/useAssignmentQueueStore/useAssignmentQueueStore";
+import useAssignmentSubmitStoreFacade from "../../stores/useAssignmentSubmitStore/useAssignmentSubmitStore.facade";
+import useQueueStoreFacade from "../../stores/useQueueStore/useQueueStore.facade";
+import { useAssignmentQueue } from "./AssignmentQueueCards.hooks";
+import {
+  AssignmentQueueItem,
+  AssignmentSubmitInfo,
+} from "../../types/AssignmentQueueTypes";
 import AssignmentQueueCards, { CardProps } from ".";
-import { render } from "../../testing/test-utils";
-import { AssignmentSubmitInfo } from "../../types/AssignmentQueueTypes";
 
-describe("<AssignmentQueueCards/>", () => {
-  test("AssignmentQueueCards renders", () => {
-    const emptySubmitInfo: AssignmentSubmitInfo = {
-      assignmentData: [],
-      submitResponses: [],
-      errors: [],
-    };
+const mockReviewAndLessonResponses = (
+  assignmentUpdated: AssignmentQueueItem
+) => {
+  const reviewUpdateResponse = fakeReviewUpdatedResponse(
+    assignmentUpdated.subject_id,
+    assignmentUpdated.object,
+    assignmentUpdated.assignment_id
+  );
+  server.use(
+    http.post(reviewsEndpoint, () => {
+      return HttpResponse.json(reviewUpdateResponse);
+    })
+  );
 
-    const submitItemsMock = vi.fn();
-    const submitBatchMock = vi.fn().mockResolvedValue(emptySubmitInfo);
-    const updateSubmittedMock = vi.fn();
-
-    const { baseElement } = renderComponent({
-      submitItems: submitItemsMock,
-      submitBatch: submitBatchMock,
-      updateSubmitted: updateSubmittedMock,
-    });
-    expect(baseElement).toBeDefined();
+  const correspondingSubj = createCorrespondingSubject(
+    assignmentUpdated.subject_id,
+    assignmentUpdated.object
+  );
+  const assignmentCreatedResponse = generatePreFlattenedAssignment({
+    correspondingSubject: correspondingSubj,
+    isLesson: true,
   });
+  server.use(
+    http.put(`${assignmentsEndpoint}/*/start`, () => {
+      return HttpResponse.json(assignmentCreatedResponse);
+    })
+  );
+};
+
+const settingTypes = ["reviews", "lessons"] as const;
+
+const mockCallbackParams = (submitInfo: AssignmentSubmitInfo) => {
+  const submitItemsMock = vi.fn();
+  const submitBatchMock = vi.fn().mockResolvedValue(submitInfo);
+  const updateSubmittedMock = vi.fn();
+
+  return {
+    submitItems: submitItemsMock,
+    submitBatch: submitBatchMock,
+    updateSubmitted: updateSubmittedMock,
+  };
+};
+
+const getComponentProps = (page: "reviews" | "lessons") => {
+  if (page === "reviews") {
+    return {
+      currPath: "/reviews/session" as const,
+      settingsType: "review" as const,
+    };
+  }
+
+  return {
+    currPath: "/lessons/quiz" as const,
+    settingsType: "lesson" as const,
+  };
+};
+
+test("AssignmentQueueCards renders", () => {
+  const emptySubmitInfo: AssignmentSubmitInfo = {
+    assignmentData: [],
+    submitResponses: [],
+    errors: [],
+  };
+  const callbackParams = mockCallbackParams(emptySubmitInfo);
+  const selectedSettingType = faker.helpers.arrayElement(settingTypes);
+  const componentProps = getComponentProps(selectedSettingType);
+
+  const { baseElement } = renderComponent(
+    callbackParams,
+    componentProps.currPath
+  );
+  expect(baseElement).toBeDefined();
 });
 
-const renderComponent = (props: CardProps) => {
-  return render(<AssignmentQueueCards {...props} />);
+// TODO: finish this test, user will enter answer and check it's been marked as correct
+test.todo("Correct answer is marked as correct", () => {
+  const selectedSettingType = faker.helpers.arrayElement(settingTypes);
+  const componentProps = getComponentProps(selectedSettingType);
+  const queueItems = generateRandomQueueItems({
+    numItems: 10,
+    queueProgressState: "not_started",
+  });
+  const { result: assignmentQueueStoreResult } = renderHook(() =>
+    useAssignmentQueueStore()
+  );
+  act(() =>
+    assignmentQueueStoreResult.current.setAssignmentQueueData(
+      queueItems,
+      componentProps.settingsType
+    )
+  );
+
+  const queueItem = queueItems[0];
+  mockReviewAndLessonResponses(queueItem);
+  // *testing
+  console.log(
+    "🚀 ~ file: AssignmentQueueCards.test.tsx:115 ~ test ~ queueItem:",
+    queueItem
+  );
+  // *testing
+
+  const { result: queueStoreResult } = renderHook(() => useQueueStoreFacade());
+  const { result: assignmentSubmitStoreResult } = renderHook(() =>
+    useAssignmentSubmitStoreFacade()
+  );
+  const { result: assignmentQueueResult } = renderHook(() =>
+    useAssignmentQueue()
+  );
+  // const { handleNextCard, handleRetryCard } = useAssignmentQueue();
+
+  const queueSubmitInfo: AssignmentSubmitInfo = {
+    assignmentData: assignmentQueueStoreResult.current.assignmentQueue,
+    submitResponses: [],
+    errors: [],
+  };
+  const callbackParams = mockCallbackParams(queueSubmitInfo);
+
+  const { user } = renderComponent(callbackParams, componentProps.currPath);
+});
+
+const renderComponent = (
+  props: CardProps,
+  currPath: "/reviews/session" | "/lessons/quiz"
+) => {
+  return renderWithRouter({
+    routeObj: {
+      path: currPath,
+      element: <AssignmentQueueCards {...props} />,
+    },
+  });
 };

--- a/src/components/KanjiReadingMnemonic/KanjiReadingMnemonic.tsx
+++ b/src/components/KanjiReadingMnemonic/KanjiReadingMnemonic.tsx
@@ -1,9 +1,9 @@
-import { IonIcon } from "@ionic/react";
 import { Kanji, Subject } from "../../types/Subject";
 import Hint from "../Hint";
 import TxtWithSubjTags from "../TxtWithSubjTags/TxtWithSubjTags";
 import UserNote from "../UserNote";
-import ReadingIcon from "../../images/reading.svg";
+import SvgIcon from "../SvgIcon";
+import ReadingIcon from "../../images/reading.svg?react";
 import { IconHeadingContainer } from "../../styles/BaseStyledComponents";
 import {
   SubjDetailSection,
@@ -18,7 +18,7 @@ function KanjiReadingMnemonic({ kanji }: Props) {
   return (
     <SubjDetailSection>
       <IconHeadingContainer>
-        <IonIcon src={ReadingIcon} />
+        <SvgIcon icon={<ReadingIcon />} width="1.5em" height="1.5em" />
         <SubjDetailSubHeading>Reading Mnemonic</SubjDetailSubHeading>
       </IconHeadingContainer>
       <TxtWithSubjTags textWithTags={kanji.reading_mnemonic!} />

--- a/src/components/VocabReadingExplanation/VocabReadingExplanation.tsx
+++ b/src/components/VocabReadingExplanation/VocabReadingExplanation.tsx
@@ -1,9 +1,9 @@
-import { IonIcon } from "@ionic/react";
 import { Subject, Vocabulary } from "../../types/Subject";
 import Hint from "../Hint";
 import TxtWithSubjTags from "../TxtWithSubjTags/TxtWithSubjTags";
 import UserNote from "../UserNote";
-import ReadingIcon from "../../images/reading.svg";
+import SvgIcon from "../SvgIcon";
+import ReadingIcon from "../../images/reading.svg?react";
 import { IconHeadingContainer } from "../../styles/BaseStyledComponents";
 import {
   SubjDetailSection,
@@ -18,7 +18,7 @@ function VocabReadingExplanation({ vocab }: Props) {
   return (
     <SubjDetailSection>
       <IconHeadingContainer>
-        <IonIcon src={ReadingIcon} />
+        <SvgIcon icon={<ReadingIcon />} width="1.5em" height="1.5em" />
         <SubjDetailSubHeading>Reading Explanation</SubjDetailSubHeading>
       </IconHeadingContainer>
       <TxtWithSubjTags textWithTags={vocab.reading_mnemonic!} />

--- a/src/components/VocabReadings/VocabReadings.tsx
+++ b/src/components/VocabReadings/VocabReadings.tsx
@@ -1,5 +1,3 @@
-// TODO: change so not relying on IonIcon
-import { IonIcon } from "@ionic/react";
 import { motion } from "framer-motion";
 import { useAudio } from "../../hooks/useAudio";
 import { getAudioForReading } from "../../services/MiscService";
@@ -11,8 +9,9 @@ import {
   PronunciationAudio,
 } from "../../types/Subject";
 import Button from "../Button/Button";
-import SoundIcon from "../../images/sound.svg";
-import SoundOffIcon from "../../images/sound-off.svg";
+import SvgIcon from "../SvgIcon";
+import SoundIcon from "../../images/sound.svg?react";
+import SoundOffIcon from "../../images/sound-off.svg?react";
 import {
   ReadingContainer,
   SubjDetailSubHeading,
@@ -32,11 +31,6 @@ const AudioBtnContainer = styled(motion.div)`
   margin: 0;
   margin-left: 5px;
   padding: 0;
-`;
-
-const AudioIcon = styled(IonIcon)`
-  width: 1em;
-  height: 1em;
 `;
 
 const AudioBtnVariants = {
@@ -68,7 +62,11 @@ const AudioBtn = ({ url, reading }: AudioProps) => {
         backgroundColor="var(--ion-color-tertiary)"
         color="black"
       >
-        <AudioIcon icon={playing ? SoundIcon : SoundOffIcon} />
+        <SvgIcon
+          icon={playing ? <SoundIcon /> : <SoundOffIcon />}
+          width="1em"
+          height="1em"
+        />
       </Btn>
     </AudioBtnContainer>
   );

--- a/src/services/AssignmentQueueService.test.ts
+++ b/src/services/AssignmentQueueService.test.ts
@@ -3,13 +3,13 @@ import { SubjectMeaning } from "../types/Subject";
 import { getAnswersForMeaningReviews } from "./AssignmentQueueService";
 
 describe("getAnswersForMeaningReviews", () => {
-  test("Accepted auxilary meanings are returned within accepted meanings", () => {
+  test("Accepted auxiliary meanings are returned within accepted meanings", () => {
     const queueItem = generateRandomQueueItems({
       numItems: 1,
       queueProgressState: "in_progress",
     })[0];
 
-    const acceptedAuxilaryMeanings = queueItem.auxiliary_meanings.filter(
+    const acceptedAuxiliaryMeanings = queueItem.auxiliary_meanings.filter(
       (auxMeaning) => auxMeaning.type === "whitelist"
     );
     const answers = getAnswersForMeaningReviews({
@@ -17,23 +17,23 @@ describe("getAnswersForMeaningReviews", () => {
       acceptedAnswersOnly: true,
     });
 
-    const answersContainAllAcceptedAuxMeanings = acceptedAuxilaryMeanings.every(
-      (auxMeaning) =>
+    const answersContainAllAcceptedAuxMeanings =
+      acceptedAuxiliaryMeanings.every((auxMeaning) =>
         answers.some(
           (subjMeaning: SubjectMeaning) =>
             subjMeaning.meaning === auxMeaning.meaning
         )
-    );
+      );
 
     expect(answersContainAllAcceptedAuxMeanings).toBe(true);
   });
-  test("Forbidden auxilary meanings are NOT returned within accepted meanings", () => {
+  test("Forbidden auxiliary meanings are NOT returned within accepted meanings", () => {
     const queueItem = generateRandomQueueItems({
       numItems: 1,
       queueProgressState: "in_progress",
     })[0];
 
-    const forbiddenAuxilaryMeanings = queueItem.auxiliary_meanings.filter(
+    const forbiddenAuxiliaryMeanings = queueItem.auxiliary_meanings.filter(
       (auxMeaning) => auxMeaning.type === "blacklist"
     );
     const answers = getAnswersForMeaningReviews({
@@ -42,7 +42,7 @@ describe("getAnswersForMeaningReviews", () => {
     });
 
     const answersContainAllAcceptedAuxMeanings =
-      forbiddenAuxilaryMeanings.every((auxMeaning) =>
+      forbiddenAuxiliaryMeanings.every((auxMeaning) =>
         answers.every(
           (subjMeaning: SubjectMeaning) =>
             subjMeaning.meaning !== auxMeaning.meaning

--- a/src/services/AssignmentQueueService.test.ts
+++ b/src/services/AssignmentQueueService.test.ts
@@ -1,0 +1,54 @@
+import { generateRandomQueueItems } from "../testing/mocks/data-generators/assignmentQueueGenerator";
+import { SubjectMeaning } from "../types/Subject";
+import { getAnswersForMeaningReviews } from "./AssignmentQueueService";
+
+describe("getAnswersForMeaningReviews", () => {
+  test("Accepted auxilary meanings are returned within accepted meanings", () => {
+    const queueItem = generateRandomQueueItems({
+      numItems: 1,
+      queueProgressState: "in_progress",
+    })[0];
+
+    const acceptedAuxilaryMeanings = queueItem.auxiliary_meanings.filter(
+      (auxMeaning) => auxMeaning.type === "whitelist"
+    );
+    const answers = getAnswersForMeaningReviews({
+      reviewItem: queueItem,
+      acceptedAnswersOnly: true,
+    });
+
+    const answersContainAllAcceptedAuxMeanings = acceptedAuxilaryMeanings.every(
+      (auxMeaning) =>
+        answers.some(
+          (subjMeaning: SubjectMeaning) =>
+            subjMeaning.meaning === auxMeaning.meaning
+        )
+    );
+
+    expect(answersContainAllAcceptedAuxMeanings).toBe(true);
+  });
+  test("Forbidden auxilary meanings are NOT returned within accepted meanings", () => {
+    const queueItem = generateRandomQueueItems({
+      numItems: 1,
+      queueProgressState: "in_progress",
+    })[0];
+
+    const forbiddenAuxilaryMeanings = queueItem.auxiliary_meanings.filter(
+      (auxMeaning) => auxMeaning.type === "blacklist"
+    );
+    const answers = getAnswersForMeaningReviews({
+      reviewItem: queueItem,
+      acceptedAnswersOnly: true,
+    });
+
+    const answersContainAllAcceptedAuxMeanings =
+      forbiddenAuxilaryMeanings.every((auxMeaning) =>
+        answers.every(
+          (subjMeaning: SubjectMeaning) =>
+            subjMeaning.meaning !== auxMeaning.meaning
+        )
+      );
+
+    expect(answersContainAllAcceptedAuxMeanings).toBe(true);
+  });
+});

--- a/src/services/AssignmentQueueService.ts
+++ b/src/services/AssignmentQueueService.ts
@@ -11,6 +11,7 @@ import {
 import Fuse from "fuse.js";
 import { getNumObjsWithDistinctPropValue } from "../utils";
 import { INVALID_ANSWER_CHARS } from "../constants";
+import { displayToast } from "../components/Toast/Toast.service";
 import {
   GroupedReviewItems,
   ReviewAnswerValidResult,
@@ -349,7 +350,13 @@ export const isUserMeaningAnswerCorrect = (
     .filter((auxilaryMeaning) => auxilaryMeaning.type === "blacklist")
     .map((auxilaryMeaning) => auxilaryMeaning.meaning);
   if (forbiddenAnswers.includes(userAnswer)) {
-    // TODO: display a toast letting user know they entered a forbidden answer
+    displayToast({
+      toastType: "warning",
+      title: "Forbidden Answer",
+      content:
+        "You entered a meaning answer that's forbidden by the WaniKani API!",
+      timeout: 10000,
+    });
     return false;
   }
 

--- a/src/services/AssignmentQueueService.ts
+++ b/src/services/AssignmentQueueService.ts
@@ -272,14 +272,10 @@ export const getAnswersForMeaningReviews = ({
   acceptedAnswersOnly,
 }: AnswersForReviewsParams) => {
   const answers = reviewItem["meanings"];
-  const auxilaryMeanings = reviewItem["auxiliary_meanings"];
-  const acceptedAuxilaryMeanings = auxilaryMeanings
-    .filter((auxilaryMeaning) => auxilaryMeaning.type === "whitelist")
-    .map((auxilaryMeaning) => auxilaryMeaning.meaning);
-
-  // *testing
-  console.log("auxilaryMeanings: ", auxilaryMeanings);
-  // *testing
+  const auxiliaryMeanings = reviewItem["auxiliary_meanings"];
+  const acceptedAuxiliaryMeanings = auxiliaryMeanings
+    .filter((auxiliaryMeaning) => auxiliaryMeaning.type === "whitelist")
+    .map((auxiliaryMeaning) => auxiliaryMeaning.meaning);
 
   // don't think this is really possible tbh
   if (answers === undefined) {
@@ -288,7 +284,7 @@ export const getAnswersForMeaningReviews = ({
 
   const answersToConvert = [
     ...reviewItem["meaning_synonyms"],
-    ...acceptedAuxilaryMeanings,
+    ...acceptedAuxiliaryMeanings,
   ];
 
   const acceptableUserAnswers =
@@ -347,8 +343,8 @@ export const isUserMeaningAnswerCorrect = (
   userAnswer: string
 ) => {
   const forbiddenAnswers = reviewItem["auxiliary_meanings"]
-    .filter((auxilaryMeaning) => auxilaryMeaning.type === "blacklist")
-    .map((auxilaryMeaning) => auxilaryMeaning.meaning);
+    .filter((auxiliaryMeaning) => auxiliaryMeaning.type === "blacklist")
+    .map((auxiliaryMeaning) => auxiliaryMeaning.meaning);
   if (forbiddenAnswers.includes(userAnswer)) {
     displayToast({
       toastType: "warning",

--- a/src/services/ImageSrcService.ts
+++ b/src/services/ImageSrcService.ts
@@ -22,7 +22,7 @@ const sortCharacterImages = (
   imgA: SubjectCharacterImage,
   imgB: SubjectCharacterImage
 ) => {
-  let pngFileType = "image/png";
+  const pngFileType = "image/png";
 
   if (imgA.content_type === pngFileType && imgB.content_type !== pngFileType) {
     return 1;
@@ -34,10 +34,13 @@ const sortCharacterImages = (
 };
 
 export const setSubjectAvailImgs = (subject: Subject) => {
-  let updatedSubj = subject;
+  const updatedSubj = subject;
   if (updatedSubj.characters === null || updatedSubj.characters === "") {
-    let imagesSorted = updatedSubj.character_images?.sort(sortCharacterImages);
-    let imageUrls = imagesSorted?.map((image: any) => image.url);
+    const imagesSorted =
+      updatedSubj.character_images?.sort(sortCharacterImages);
+    const imageUrls = imagesSorted?.map(
+      (image: SubjectCharacterImage) => image.url
+    );
 
     updatedSubj.availableImages = imageUrls;
     updatedSubj.useImage = true;
@@ -80,38 +83,18 @@ type ButtonImgProps = {
   numItems: number;
 };
 
-export const setButtonImgSrc = ({ btnType, numItems }: ButtonImgProps) => {
-  let imgNums = btnImgSrcs[btnType].imgNums;
-  console.log(
-    "🚀 ~ file: ImageSrcService.tsx:104 ~ setButtonImgSrc ~ imgNums:",
-    imgNums
-  );
-  let maxedOut = imgNums.at(-1);
-
-  let imageClassNum = Math.min(
-    ...imgNums.filter((num: number) => num >= numItems)
-  );
-
-  let bgVarName =
-    imageClassNum == Infinity
-      ? `${btnType}BgImg${maxedOut}`
-      : `${btnType}BgImg${imageClassNum}`;
-
-  return bgVarName;
-};
-
 export const setBtnBackground = ({ btnType, numItems }: ButtonImgProps) => {
-  let imgNums = btnImgSrcs[btnType].imgNums;
-  let maxedOut = imgNums.at(-1);
+  const imgNums = btnImgSrcs[btnType].imgNums;
+  const maxedOut = imgNums[imgNums.length - 1];
 
-  let imageClassNum = Math.min(
+  const imageClassNum = Math.min(
     ...imgNums.filter((num: number) => num >= numItems)
   );
 
-  let bgVarName =
+  const bgVarName =
     imageClassNum == Infinity
       ? `${btnType}BgImg${maxedOut}`
       : `${btnType}BgImg${imageClassNum}`;
-  let bgSrc = btnImgSrcs[btnType].bgImages[bgVarName as keyof object];
+  const bgSrc = btnImgSrcs[btnType].bgImages[bgVarName as keyof object];
   return bgSrc;
 };

--- a/src/stores/useAssignmentQueueStore/useAssignmentQueueStore.facade.ts
+++ b/src/stores/useAssignmentQueueStore/useAssignmentQueueStore.facade.ts
@@ -3,6 +3,7 @@ import {
   AssignmentQueueState,
   AssignmentQueueActions,
   useAssignmentQueueStore,
+  initialState,
 } from "./useAssignmentQueueStore";
 
 // using facade pattern, cleaner to use in components and easier to replace zustand in future if necessary
@@ -21,7 +22,7 @@ const useAssignmentQueueStoreFacade = () => {
     addToAssignmentQueue,
     removeOldQueueItem,
     resetAll,
-  } = useAssignmentQueueStore(
+  }: AssignmentQueueState & AssignmentQueueActions = useAssignmentQueueStore(
     useShallow((state: AssignmentQueueState & AssignmentQueueActions) => ({
       assignmentQueue: state.assignmentQueue,
       currQueueIndex: state.currQueueIndex,
@@ -53,6 +54,8 @@ const useAssignmentQueueStoreFacade = () => {
     addToAssignmentQueue,
     removeOldQueueItem,
     resetAll,
+    // exporting to check that state is reset properly
+    initialState,
   };
 };
 

--- a/src/stores/useAssignmentQueueStore/useAssignmentQueueStore.test.ts
+++ b/src/stores/useAssignmentQueueStore/useAssignmentQueueStore.test.ts
@@ -1,6 +1,6 @@
 import { generateRandomQueueItems } from "../../testing/mocks/data-generators/assignmentQueueGenerator";
 import { act, renderHook } from "../../testing/test-utils";
-import { useAssignmentQueueStore } from "./useAssignmentQueueStore";
+import useAssignmentQueueStoreFacade from "./useAssignmentQueueStore.facade";
 
 const mockAssignmentQueueItems = generateRandomQueueItems({
   numItems: 20,
@@ -9,14 +9,20 @@ const mockAssignmentQueueItems = generateRandomQueueItems({
 
 describe("useAssignmentQueueStore", () => {
   test("Initial values are as expected", () => {
-    const { result } = renderHook(() => useAssignmentQueueStore());
-    expect(result.current.currQueueIndex).toEqual(0);
-    expect(result.current.sessionInProgress).toEqual(false);
-    expect(result.current.sessionType).toEqual("review");
+    const { result } = renderHook(() => useAssignmentQueueStoreFacade());
+    expect(result.current.currQueueIndex).toEqual(
+      result.current.initialState.currQueueIndex
+    );
+    expect(result.current.sessionInProgress).toEqual(
+      result.current.initialState.sessionInProgress
+    );
+    expect(result.current.sessionType).toEqual(
+      result.current.initialState.sessionType
+    );
   });
 
   test("currQueueIndex increments", () => {
-    const { result } = renderHook(() => useAssignmentQueueStore());
+    const { result } = renderHook(() => useAssignmentQueueStoreFacade());
     expect(result.current.currQueueIndex).toEqual(0);
     act(() => result.current.incrementCurrQueueIndex());
     expect(result.current.currQueueIndex).toEqual(1);
@@ -25,7 +31,7 @@ describe("useAssignmentQueueStore", () => {
   });
 
   test("currQueueIndex resets", () => {
-    const { result } = renderHook(() => useAssignmentQueueStore());
+    const { result } = renderHook(() => useAssignmentQueueStoreFacade());
     expect(result.current.currQueueIndex).toEqual(0);
     act(() => result.current.incrementCurrQueueIndex());
     expect(result.current.currQueueIndex).toEqual(1);
@@ -34,7 +40,7 @@ describe("useAssignmentQueueStore", () => {
   });
 
   test("Submitted states for queue items update", () => {
-    const { result } = renderHook(() => useAssignmentQueueStore());
+    const { result } = renderHook(() => useAssignmentQueueStoreFacade());
 
     // adding some mock assignments to the queue
     act(() =>

--- a/src/stores/useAssignmentQueueStore/useAssignmentQueueStore.ts
+++ b/src/stores/useAssignmentQueueStore/useAssignmentQueueStore.ts
@@ -30,7 +30,7 @@ export interface AssignmentQueueActions {
   removeOldQueueItem: () => void;
   resetAll: () => void;
 }
-const initialState: AssignmentQueueState = {
+export const initialState: AssignmentQueueState = {
   currQueueIndex: 0,
   assignmentQueue: [],
   sessionInProgress: false,

--- a/src/stores/useAssignmentSubmitStore/useAssignmentSubmitStore.facade.ts
+++ b/src/stores/useAssignmentSubmitStore/useAssignmentSubmitStore.facade.ts
@@ -2,6 +2,7 @@ import { useShallow } from "zustand/react/shallow";
 import {
   AssignmentSubmitActions,
   AssignmentSubmitState,
+  initialState,
   useAssignmentSubmitStore,
 } from "./useAssignmentSubmitStore";
 
@@ -15,7 +16,7 @@ const useAssignmentSubmitStoreFacade = () => {
     updateSubmittedQueueItems,
     setShouldBatchSubmit,
     resetAll,
-  } = useAssignmentSubmitStore(
+  }: AssignmentSubmitState & AssignmentSubmitActions = useAssignmentSubmitStore(
     useShallow((state: AssignmentSubmitState & AssignmentSubmitActions) => ({
       shouldBatchSubmit: state.shouldBatchSubmit,
       submittedAssignmentQueueItems: state.submittedAssignmentQueueItems,
@@ -35,6 +36,8 @@ const useAssignmentSubmitStoreFacade = () => {
     updateSubmittedQueueItems,
     setShouldBatchSubmit,
     resetAll,
+    // exporting to check that state is reset properly
+    initialState,
   };
 };
 

--- a/src/stores/useAssignmentSubmitStore/useAssignmentSubmitStore.test.ts
+++ b/src/stores/useAssignmentSubmitStore/useAssignmentSubmitStore.test.ts
@@ -10,8 +10,12 @@ const mockAssignmentQueueItems = generateRandomQueueItems({
 describe("useAssignmentSubmitStore", () => {
   test("Initial values are as expected", () => {
     const { result } = renderHook(() => useAssignmentSubmitStoreFacade());
-    expect(result.current.submittedAssignmentsWithErrs).toEqual([]);
-    expect(result.current.shouldBatchSubmit).toEqual(false);
+    expect(result.current.submittedAssignmentsWithErrs).toEqual(
+      result.current.initialState.submittedAssignmentsWithErrs
+    );
+    expect(result.current.shouldBatchSubmit).toEqual(
+      result.current.initialState.shouldBatchSubmit
+    );
   });
 
   test("Submitted queue items added", () => {

--- a/src/stores/useAssignmentSubmitStore/useAssignmentSubmitStore.ts
+++ b/src/stores/useAssignmentSubmitStore/useAssignmentSubmitStore.ts
@@ -16,7 +16,8 @@ export interface AssignmentSubmitActions {
   setShouldBatchSubmit: (shouldBatchSubmit: boolean) => void;
   resetAll: () => void;
 }
-const initialState: AssignmentSubmitState = {
+
+export const initialState: AssignmentSubmitState = {
   submittedAssignmentsWithErrs: [],
   submittedAssignmentQueueItems: [],
   shouldBatchSubmit: false,

--- a/src/stores/useAuthTokenStore/useAuthTokenStore.facade.ts
+++ b/src/stores/useAuthTokenStore/useAuthTokenStore.facade.ts
@@ -3,6 +3,7 @@ import {
   AuthTokenState,
   AuthTokenActions,
   useAuthTokenStore,
+  initialState,
 } from "./useAuthTokenStore";
 
 // using facade pattern, cleaner to use in components and easier to replace zustand in future if necessary
@@ -15,7 +16,7 @@ const useAuthTokenStoreFacade = () => {
     setIsAuthLoading,
     setIsAuthenticated,
     reset,
-  } = useAuthTokenStore(
+  }: AuthTokenState & AuthTokenActions = useAuthTokenStore(
     useShallow((state: AuthTokenState & AuthTokenActions) => ({
       authToken: state.authToken,
       isAuthenticated: state.isAuthenticated,
@@ -35,6 +36,8 @@ const useAuthTokenStoreFacade = () => {
     setIsAuthLoading,
     setIsAuthenticated,
     reset,
+    // exporting to check that state is reset properly
+    initialState,
   };
 };
 

--- a/src/stores/useAuthTokenStore/useAuthTokenStore.ts
+++ b/src/stores/useAuthTokenStore/useAuthTokenStore.ts
@@ -27,7 +27,7 @@ const storage: StateStorage = {
   },
 };
 
-const initialState: AuthTokenState = {
+export const initialState: AuthTokenState = {
   authToken: null,
   isAuthenticated: false,
   isAuthLoading: false,

--- a/src/stores/useForecastTotalsStore/useForecastTotalsStore.facade.ts
+++ b/src/stores/useForecastTotalsStore/useForecastTotalsStore.facade.ts
@@ -3,6 +3,7 @@ import {
   ForeCastTotalsState,
   ForeCastTotalsActions,
   useForecastTotalsStore,
+  initialState,
 } from "./useForecastTotalsStore";
 
 // using facade pattern, cleaner to use in components and easier to replace zustand in future if necessary
@@ -12,7 +13,7 @@ const useForecastTotalsStoreFacade = () => {
     seedRunningTotalAvailableReviews,
     updateRunningTotalAvailableReviews,
     resetAll,
-  } = useForecastTotalsStore(
+  }: ForeCastTotalsState & ForeCastTotalsActions = useForecastTotalsStore(
     useShallow((state: ForeCastTotalsState & ForeCastTotalsActions) => ({
       runningTotalAvailableReviews: state.runningTotalAvailableReviews,
       seedRunningTotalAvailableReviews: state.seedRunningTotalAvailableReviews,
@@ -27,6 +28,8 @@ const useForecastTotalsStoreFacade = () => {
     seedRunningTotalAvailableReviews,
     updateRunningTotalAvailableReviews,
     resetAll,
+    // exporting to check that state is reset properly
+    initialState,
   };
 };
 

--- a/src/stores/useForecastTotalsStore/useForecastTotalsStore.ts
+++ b/src/stores/useForecastTotalsStore/useForecastTotalsStore.ts
@@ -13,7 +13,7 @@ export interface ForeCastTotalsActions {
   resetAll: () => void;
 }
 
-const initialState: ForeCastTotalsState = {
+export const initialState: ForeCastTotalsState = {
   runningTotalAvailableReviews: [],
 };
 

--- a/src/stores/useLessonPaginatorStore/useLessonPaginatorStore.facade.ts
+++ b/src/stores/useLessonPaginatorStore/useLessonPaginatorStore.facade.ts
@@ -3,6 +3,7 @@ import {
   LessonPaginatorState,
   LessonPaginatorActions,
   useLessonPaginatorStore,
+  initialState,
 } from "./useLessonPaginatorStore";
 
 // using facade pattern, cleaner to use in components and easier to replace zustand in future if necessary
@@ -12,7 +13,7 @@ const useLessonPaginatorStoreFacade = () => {
     currentLessonDir,
     setCurrentLessonPageAndDir,
     reset,
-  } = useLessonPaginatorStore(
+  }: LessonPaginatorState & LessonPaginatorActions = useLessonPaginatorStore(
     useShallow((state: LessonPaginatorState & LessonPaginatorActions) => ({
       currentLessonPage: state.currentLessonPage,
       currentLessonDir: state.currentLessonDir,
@@ -26,6 +27,8 @@ const useLessonPaginatorStoreFacade = () => {
     currentLessonDir,
     setCurrentLessonPageAndDir,
     reset,
+    // exporting to check that state is reset properly
+    initialState,
   };
 };
 

--- a/src/stores/useLessonPaginatorStore/useLessonPaginatorStore.ts
+++ b/src/stores/useLessonPaginatorStore/useLessonPaginatorStore.ts
@@ -13,7 +13,7 @@ export interface LessonPaginatorActions {
   reset: () => void;
 }
 
-const initialState: LessonPaginatorState = {
+export const initialState: LessonPaginatorState = {
   currentLessonPage: 0,
   currentLessonDir: 0,
 };

--- a/src/stores/useQueueStore/useQueueStore.facade.ts
+++ b/src/stores/useQueueStore/useQueueStore.facade.ts
@@ -1,5 +1,10 @@
 import { useShallow } from "zustand/react/shallow";
-import { QueueState, QueueActions, useQueueStore } from "./useQueueStore";
+import {
+  QueueState,
+  QueueActions,
+  useQueueStore,
+  initialState,
+} from "./useQueueStore";
 
 // using facade pattern, cleaner to use in components and easier to replace zustand in future if necessary
 const useQueueStoreFacade = () => {
@@ -19,7 +24,7 @@ const useQueueStoreFacade = () => {
     wrongShowResult,
     submitChoice,
     resetAll,
-  } = useQueueStore(
+  }: QueueState & QueueActions = useQueueStore(
     useShallow((state: QueueState & QueueActions) => ({
       isSubmittingAnswer: state.isSubmittingAnswer,
       isBottomSheetVisible: state.isBottomSheetVisible,
@@ -55,6 +60,8 @@ const useQueueStoreFacade = () => {
     wrongShowResult,
     submitChoice,
     resetAll,
+    // exporting to check that state is reset properly
+    initialState,
   };
 };
 

--- a/src/stores/useQueueStore/useQueueStore.test.ts
+++ b/src/stores/useQueueStore/useQueueStore.test.ts
@@ -4,14 +4,22 @@ import useQueueStoreFacade from "./useQueueStore.facade";
 describe("useQueueStore", () => {
   test("Initial values are as expected", async () => {
     const { result } = renderHook(() => useQueueStoreFacade());
-    expect(result.current.isSubmittingAnswer).toEqual(false);
-    expect(result.current.isBottomSheetVisible).toEqual(false);
-    expect(result.current.popoverInfo).toEqual({
-      message: "",
-      messageType: "invalid",
-    });
-    expect(result.current.displayPopoverMsg).toEqual(false);
-    expect(result.current.savedUserAnswer).toEqual(null);
+
+    expect(result.current.isSubmittingAnswer).toEqual(
+      result.current.initialState.isSubmittingAnswer
+    );
+    expect(result.current.isBottomSheetVisible).toEqual(
+      result.current.initialState.isBottomSheetVisible
+    );
+    expect(result.current.popoverInfo).toEqual(
+      result.current.initialState.popoverInfo
+    );
+    expect(result.current.displayPopoverMsg).toEqual(
+      result.current.initialState.displayPopoverMsg
+    );
+    expect(result.current.savedUserAnswer).toEqual(
+      result.current.initialState.savedUserAnswer
+    );
   });
 
   test("isSubmittingAnswer updates", () => {

--- a/src/stores/useQueueStore/useQueueStore.ts
+++ b/src/stores/useQueueStore/useQueueStore.ts
@@ -22,7 +22,7 @@ export interface QueueActions {
   resetAll: () => void;
 }
 
-const initialState: QueueState = {
+export const initialState: QueueState = {
   isSubmittingAnswer: false,
   isBottomSheetVisible: false,
   popoverInfo: { message: "", messageType: "invalid" },

--- a/src/stores/useUserInfoStore/useUserInfoStore.facade.ts
+++ b/src/stores/useUserInfoStore/useUserInfoStore.facade.ts
@@ -3,22 +3,26 @@ import {
   UserInfoState,
   UserInfoActions,
   useUserInfoStore,
+  initialState,
 } from "./useUserInfoStore";
 
 // using facade pattern, cleaner to use in components and easier to replace zustand in future if necessary
 const useUserInfoStoreFacade = () => {
-  const { userInfo, setUserInfo, reset } = useUserInfoStore(
-    useShallow((state: UserInfoState & UserInfoActions) => ({
-      userInfo: state.userInfo,
-      setUserInfo: state.setUserInfo,
-      reset: state.reset,
-    }))
-  );
+  const { userInfo, setUserInfo, reset }: UserInfoState & UserInfoActions =
+    useUserInfoStore(
+      useShallow((state: UserInfoState & UserInfoActions) => ({
+        userInfo: state.userInfo,
+        setUserInfo: state.setUserInfo,
+        reset: state.reset,
+      }))
+    );
 
   return {
     userInfo,
     setUserInfo,
     reset,
+    // exporting to check that state is reset properly
+    initialState,
   };
 };
 

--- a/src/stores/useUserInfoStore/useUserInfoStore.ts
+++ b/src/stores/useUserInfoStore/useUserInfoStore.ts
@@ -11,7 +11,7 @@ export interface UserInfoActions {
   reset: () => void;
 }
 
-const initialState: UserInfoState = {
+export const initialState: UserInfoState = {
   userInfo: undefined,
 };
 

--- a/src/stores/useUserSettingsStore/useUserSettingsStore.facade.ts
+++ b/src/stores/useUserSettingsStore/useUserSettingsStore.facade.ts
@@ -3,6 +3,7 @@ import {
   UserSettingsState,
   UserSettingsActions,
   useUserSettingsStore,
+  initialState,
 } from "./useUserSettingsStore";
 
 // using facade pattern, cleaner to use in components and easier to replace zustand in future if necessary
@@ -22,7 +23,7 @@ const useUserSettingsStoreFacade = () => {
     setReviewSortOrderOption,
     setReviewBackToBackOption,
     setPrefersDarkModeTheme,
-  } = useUserSettingsStore(
+  }: UserSettingsState & UserSettingsActions = useUserSettingsStore(
     useShallow((state: UserSettingsState & UserSettingsActions) => ({
       pronunciationVoice: state.pronunciationVoice,
       lessonBatchSize: state.lessonBatchSize,
@@ -56,6 +57,8 @@ const useUserSettingsStoreFacade = () => {
     setReviewSortOrderOption,
     setReviewBackToBackOption,
     setPrefersDarkModeTheme,
+    // exporting to check that state is reset properly
+    initialState,
   };
 };
 

--- a/src/stores/useUserSettingsStore/useUserSettingsStore.ts
+++ b/src/stores/useUserSettingsStore/useUserSettingsStore.ts
@@ -25,7 +25,7 @@ export interface UserSettingsActions {
   setPrefersDarkModeTheme: (isDarkMode: boolean) => void;
 }
 
-const initialState: UserSettingsState = {
+export const initialState: UserSettingsState = {
   pronunciationVoice: {
     id: "female_tokyo",
     details: {

--- a/src/testing/endpoints.ts
+++ b/src/testing/endpoints.ts
@@ -4,6 +4,7 @@ export const userEndpoint = `${baseUrl}user`;
 export const assignmentsEndpoint = `${baseUrl}assignments`;
 export const subjectsEndpoint = `${baseUrl}subjects`;
 export const studyMaterialsEndpoint = `${baseUrl}study_materials`;
+export const reviewsEndpoint = `${baseUrl}reviews`;
 
 export const AVAIL_REVIEWS = "immediately_available_for_review";
 export const AVAIL_LESSONS = "immediately_available_for_lessons";

--- a/src/testing/mocks/data-generators/assignmentQueueGenerator.ts
+++ b/src/testing/mocks/data-generators/assignmentQueueGenerator.ts
@@ -59,10 +59,10 @@ type RandomQueueItemsGeneratorParams = Omit<
 
 export const generateRandomQueueItems = ({
   numItems,
+  queueProgressState,
   areLessons,
   level,
   backToBackChoice,
-  queueProgressState,
   allCorrect,
 }: RandomQueueItemsGeneratorParams): AssignmentQueueItem[] => {
   const mockSubjects = generateSubjArray({ numSubjects: numItems, level });

--- a/src/testing/mocks/data-generators/reviewGenerator.ts
+++ b/src/testing/mocks/data-generators/reviewGenerator.ts
@@ -1,0 +1,98 @@
+import { faker } from "@faker-js/faker";
+import { reviewsEndpoint } from "../../endpoints";
+import { SubjectType } from "../../../types/Subject";
+import { ReviewStatistic, ReviewUpdateResponse } from "../../../types/Review";
+import { PreFlattenedAssignment } from "../../../types/Assignment";
+import { VALID_SRS_STAGES } from "../../../constants";
+
+// TODO: pass in starting and ending SRS stages, incorrect meaning/reading answers
+export const fakeReviewUpdatedResponse = (
+  subjectID: number,
+  subType: SubjectType,
+  assignmentID?: number
+): ReviewUpdateResponse => {
+  const asgmtID = assignmentID || faker.number.int({ min: 1 });
+
+  const mockReviewUpdate: ReviewUpdateResponse = {
+    id: faker.number.int(),
+    object: "review",
+    url: reviewsEndpoint,
+    data_updated_at: faker.date.past(),
+    data: {
+      created_at: faker.date.past(),
+      assignment_id: asgmtID,
+      subject_id: subjectID,
+      spaced_repetition_system_id: faker.number.int(),
+      starting_srs_stage: faker.helpers.rangeToNumber({
+        min: VALID_SRS_STAGES[0],
+        max: VALID_SRS_STAGES[VALID_SRS_STAGES.length - 1],
+      }),
+      ending_srs_stage: faker.helpers.rangeToNumber({
+        min: VALID_SRS_STAGES[0],
+        max: VALID_SRS_STAGES[VALID_SRS_STAGES.length - 1],
+      }),
+      incorrect_meaning_answers: 1,
+      incorrect_reading_answers: 2,
+    },
+    resources_updated: {
+      assignment: fakeAssignmentUpdated(subjectID, subType, asgmtID),
+      review_statistic: fakeReviewStatistic(subjectID, subType),
+    },
+  };
+
+  return mockReviewUpdate;
+};
+
+// TODO: pass in isBurned, isResurrected, etc.
+const fakeAssignmentUpdated = (
+  subjectID: number,
+  subjType: SubjectType,
+  assignmentID: number
+): PreFlattenedAssignment => {
+  return {
+    id: assignmentID,
+    object: "assignment",
+    url: faker.internet.url(),
+    data_updated_at: faker.date.past(),
+    data: {
+      created_at: faker.date.past(),
+      subject_id: subjectID,
+      subject_type: subjType,
+      srs_stage: faker.number.int({ min: 1, max: 9 }),
+      unlocked_at: faker.date.past(),
+      started_at: faker.date.past(),
+      passed_at: faker.date.past(),
+      burned_at: null,
+      available_at: faker.date.past(),
+      resurrected_at: null,
+      hidden: false,
+    },
+  };
+};
+
+const fakeReviewStatistic = (
+  subjectID: number,
+  subjType: SubjectType
+): ReviewStatistic => {
+  return {
+    id: faker.number.int(),
+    object: "review_statistic",
+    url: faker.internet.url(),
+    data_updated_at: faker.date.past(),
+    data: {
+      created_at: faker.date.past(),
+      subject_id: subjectID,
+      subject_type: subjType,
+      meaning_correct: faker.number.int(),
+      meaning_incorrect: faker.number.int(),
+      meaning_max_streak: faker.number.int(),
+      meaning_current_streak: faker.number.int(),
+      reading_correct: faker.number.int(),
+      reading_incorrect: faker.number.int(),
+      reading_max_streak: faker.number.int(),
+      reading_current_streak: faker.number.int(),
+      percentage_correct: faker.number.int(),
+      hidden: false,
+    },
+  };
+};

--- a/src/testing/mocks/data-generators/subjAssignmentPairGenerator.ts
+++ b/src/testing/mocks/data-generators/subjAssignmentPairGenerator.ts
@@ -41,6 +41,8 @@ type SubjAssignmentPairGeneratorParams = {
   level?: number;
   assignmentBurned?: boolean;
   assignmentResurrected?: boolean;
+  hasAllowedAuxMeanings?: boolean;
+  hasForbiddenAuxMeanings?: boolean;
 };
 
 export const generateSubjAssignmentPair = ({
@@ -49,8 +51,16 @@ export const generateSubjAssignmentPair = ({
   level,
   assignmentBurned = false,
   assignmentResurrected = false,
+  hasAllowedAuxMeanings,
+  hasForbiddenAuxMeanings,
 }: SubjAssignmentPairGeneratorParams): SubjAssignmentPair => {
-  const subject: Subject = generateSubject({ subjType, imagesOnly, level });
+  const subject: Subject = generateSubject({
+    subjType,
+    imagesOnly,
+    level,
+    hasAllowedAuxMeanings,
+    hasForbiddenAuxMeanings,
+  });
   const assignment: Assignment = generateAssignment({
     isBurned: assignmentBurned,
     isResurrected: assignmentResurrected,
@@ -69,8 +79,15 @@ export const generatePreflattenedSubjAssignmentPair = ({
   level,
   assignmentBurned = false,
   assignmentResurrected = false,
+  hasAllowedAuxMeanings,
+  hasForbiddenAuxMeanings,
 }: PreflattenedSubjAssignmentPairGeneratorParams): PreflattenedSubjAssignmentPair => {
-  const preflattenedSubject = generatePreFlattenedSubject({ subjType, level });
+  const preflattenedSubject = generatePreFlattenedSubject({
+    subjType,
+    level,
+    hasAllowedAuxMeanings,
+    hasForbiddenAuxMeanings,
+  });
 
   const preflattenedAssignment = generatePreFlattenedAssignment({
     isBurned: assignmentBurned,
@@ -87,6 +104,8 @@ type SubjAssignmentPairArrGeneratorParams = {
   assignmentsStarted?: boolean;
   assignmentsBurned?: boolean;
   assignmentsResurrected?: boolean;
+  hasAllowedAuxMeanings?: boolean;
+  hasForbiddenAuxMeanings?: boolean;
 };
 
 export const generateSubjAssignmentPairArray = ({
@@ -96,12 +115,16 @@ export const generateSubjAssignmentPairArray = ({
   level,
   assignmentsBurned = false,
   assignmentsResurrected = false,
+  hasAllowedAuxMeanings,
+  hasForbiddenAuxMeanings,
 }: SubjAssignmentPairArrGeneratorParams): SubjAssignmentPairArr => {
   const subjArr = generateSubjArray({
     numSubjects: numPairs,
     subjTypes,
     imagesOnly,
     level,
+    hasAllowedAuxMeanings,
+    hasForbiddenAuxMeanings,
   });
   const assignArr = subjArr.map((subj) =>
     generateAssignment({
@@ -126,11 +149,15 @@ export const generatePreflattenedSubjAssignmentPairArray = ({
   level,
   assignmentsBurned = false,
   assignmentsResurrected = false,
+  hasAllowedAuxMeanings,
+  hasForbiddenAuxMeanings,
 }: PreflattenedSubjAssignmentPairArrGeneratorParams): PreflattenedSubjAssignmentPairArr => {
   const preflattenedSubjects = generatePreflattenedSubjArray({
     numSubjects: numPairs,
     subjTypes,
     level,
+    hasAllowedAuxMeanings,
+    hasForbiddenAuxMeanings,
   });
 
   const preflattenedAssignments = preflattenedSubjects.map((subj) =>

--- a/src/testing/setup.ts
+++ b/src/testing/setup.ts
@@ -1,6 +1,5 @@
 import { setupIonicReact } from "@ionic/react";
 import { expect, afterEach, vi } from "vitest";
-import { cleanup } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import { server } from "./mocks/server";
@@ -38,6 +37,8 @@ Object.defineProperty(window, "matchMedia", {
   })),
 });
 
+HTMLMediaElement.prototype.pause = vi.fn();
+
 vi.mock("zustand");
 
 // extends Vitest's expect method with methods from react-testing-library
@@ -53,7 +54,6 @@ beforeAll(() => server.listen());
 // clean up after each test case
 afterEach(() => {
   server.resetHandlers();
-  cleanup();
 });
 
 // clean up after the tests are finished.


### PR DESCRIPTION
- Now checking auxiliary meanings for allowed and forbidden answers when user enters meaning
  - Marked as incorrect and toast is displayed when forbidden meaning is entered
  - Tests created for accurate auxiliary meanings being returned
- Removed use of `.at` as not supported in all browsers/some older versions of Chrome