### PR TITLE
Radical Mixup Bug

### DIFF
--- a/src/hooks/useRadicalAssignmentsForLvl.ts
+++ b/src/hooks/useRadicalAssignmentsForLvl.ts
@@ -1,4 +1,3 @@
-import { useCallback } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { WaniKaniAPI } from "../api/WaniKaniApi";
 import { flattenData } from "../services/MiscService";
@@ -8,11 +7,8 @@ export const useRadicalAssignmentsForLvl = (level: any) => {
     queryKey: ["radical-assignments-for-lvl", level],
     queryFn: () => WaniKaniAPI.getRadicalAssignmentsByLvl(level),
     enabled: !!level,
-    select: useCallback(
-      (data: any) => {
-        return flattenData(data);
-      },
-      [level]
-    ),
+    select: (data: any) => {
+      return flattenData(data);
+    },
   });
 };

--- a/src/hooks/useRadicalSubjectsForLvl.ts
+++ b/src/hooks/useRadicalSubjectsForLvl.ts
@@ -1,36 +1,32 @@
-import { useCallback } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { WaniKaniAPI } from "../api/WaniKaniApi";
 import { setSubjectAvailImgs } from "../services/ImageSrcService";
 import { flattenData } from "../services/MiscService";
-import { Radical } from "../types/Subject";
+import { Radical, Subject } from "../types/Subject";
 
 export const useRadicalSubjectsForLvl = (level: any) => {
   return useQuery({
     queryKey: ["radical-subjects-for-lvl", level],
     queryFn: () => WaniKaniAPI.getRadicalSubjectsByLevel(level),
     enabled: !!level,
-    select: useCallback(
-      (data: any) => {
-        let flattened = flattenData(data);
+    select: (data: any) => {
+      const flattened = flattenData(data);
 
-        let radsUpdated = flattened.reduce(function (
-          filtered: any,
-          subject: any
-        ) {
-          let updatedSubj = setSubjectAvailImgs(subject);
-          filtered.push(updatedSubj);
+      const radsUpdated = flattened.reduce(function (
+        filtered: Subject[],
+        subject: Subject
+      ) {
+        const updatedSubj = setSubjectAvailImgs(subject);
+        filtered.push(updatedSubj);
 
-          return filtered;
-        }, []);
+        return filtered;
+      }, []);
 
-        let noLoneRadicalsAllowed = radsUpdated.filter(
-          (radical: Radical) => radical.amalgamation_subject_ids.length !== 0
-        );
-        return noLoneRadicalsAllowed;
-      },
-      [level]
-    ),
+      const noLoneRadicalsAllowed = radsUpdated.filter(
+        (radical: Radical) => radical.amalgamation_subject_ids.length !== 0
+      );
+      return noLoneRadicalsAllowed;
+    },
     // stale time of an hour
     staleTime: 60 * (60 * 1000),
     // cache time of 1hr 15 minutes

--- a/src/hooks/useSubjectsByIDs.ts
+++ b/src/hooks/useSubjectsByIDs.ts
@@ -1,8 +1,8 @@
-import { useCallback } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { WaniKaniAPI } from "../api/WaniKaniApi";
 import { setSubjectAvailImgs } from "../services/ImageSrcService";
 import { flattenData } from "../services/MiscService";
+import { Subject } from "../types/Subject";
 
 export const useSubjectsByIDs = (
   ids: number[],
@@ -13,30 +13,27 @@ export const useSubjectsByIDs = (
     queryKey: ["subjects-by-ids", ids],
     queryFn: () => WaniKaniAPI.getSubjectsBySubjIDs(ids),
     enabled: enabled && ids.length !== 0,
-    select: useCallback(
-      (data: any) => {
-        let flattened = flattenData(data);
+    select: (data: any) => {
+      const flattened = flattenData(data);
 
-        let subjsUpdated = flattened.reduce(function (
-          filtered: any,
-          subject: any
-        ) {
-          let updatedSubj = setSubjectAvailImgs(subject);
-          filtered.push(updatedSubj);
-          return filtered;
-        }, []);
+      const subjsUpdated = flattened.reduce(function (
+        filtered: Subject[],
+        subject: Subject
+      ) {
+        const updatedSubj = setSubjectAvailImgs(subject);
+        filtered.push(updatedSubj);
+        return filtered;
+      }, []);
 
-        if (sortByLvl) {
-          let sortedByLvl = subjsUpdated.sort(
-            (a: any, b: any) => a.level - b.level
-          );
-          return sortedByLvl;
-        }
+      if (sortByLvl) {
+        const sortedByLvl = subjsUpdated.sort(
+          (a: Subject, b: Subject) => a.level - b.level
+        );
+        return sortedByLvl;
+      }
 
-        return subjsUpdated;
-      },
-      [ids]
-    ),
+      return subjsUpdated;
+    },
     // stale time of an hour
     staleTime: 60 * (60 * 1000),
     // cache time of 1hr 15 minutes

--- a/src/hooks/useSubjectsByLevel.ts
+++ b/src/hooks/useSubjectsByLevel.ts
@@ -2,8 +2,9 @@ import { useQuery } from "@tanstack/react-query";
 import { WaniKaniAPI } from "../api/WaniKaniApi";
 import { setSubjectAvailImgs } from "../services/ImageSrcService";
 import { flattenData } from "../services/MiscService";
+import { Subject } from "../types/Subject";
 
-export const useSubjectsByLevel = (level: any, enabled: boolean = true) => {
+export const useSubjectsByLevel = (level: number, enabled: boolean = true) => {
   return useQuery({
     queryKey: ["subjects-by-lvl", level],
     queryFn: () => WaniKaniAPI.getSubjectsByLevel(level),
@@ -13,8 +14,8 @@ export const useSubjectsByLevel = (level: any, enabled: boolean = true) => {
       const flattened = flattenData(data);
 
       const subjectsUpdated = flattened.reduce(function (
-        filtered: any,
-        subject: any
+        filtered: Subject[],
+        subject: Subject
       ) {
         const updatedSubj = setSubjectAvailImgs(subject);
         filtered.push(updatedSubj);


### PR DESCRIPTION
Some users are seeing the wrong radicals being displayed on lesson and review quizzes, this may be due to the use of `useCallback` when fetching subjects

- Removed usage of useCallback for a few radical and subject hooks
- Typed subjects as `Subject` arrays instead of `any`