### PR TITLE
Bug Fix for Modal Not Being Removed from DOM, Blocking User Interaction

### DIFF
--- a/src/components/AlertModal/AlertModal.tsx
+++ b/src/components/AlertModal/AlertModal.tsx
@@ -1,4 +1,4 @@
-import { useState, forwardRef } from "react";
+import { useState, forwardRef, useRef, useEffect } from "react";
 import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
 import { AnimatePresence, motion } from "framer-motion";
 import styled from "styled-components";
@@ -135,57 +135,67 @@ export const AlertModalContent = forwardRef<ContentRef, AlertModalContentProps>(
     forwardedRef
   ) => {
     const [container, setContainer] = useState<HTMLDivElement | null>(null);
+    const portalContainerRef = useRef<HTMLDivElement | null>(null);
+
+    useEffect(() => {
+      setContainer(portalContainerRef.current);
+    }, []);
 
     return (
       <>
         <AnimatePresence>
           {isOpen && (
-            <AlertDialogPrimitive.Portal forceMount container={container}>
-              <AlertDialogPrimitive.Overlay asChild>
-                <OverlayPrimitive
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1, transition: { delay: DELAY } }}
-                  exit={{ opacity: 0 }}
-                />
-              </AlertDialogPrimitive.Overlay>
-              <ContentPrimitive
-                {...props}
-                ref={forwardedRef}
-                forceMount
-                asChild
-              >
-                <Content
-                  initial={{ scale: 0 }}
-                  animate={{ scale: 1, transition: { delay: DELAY } }}
-                  exit={{ scale: 0 }}
+            <>
+              <AlertDialogPrimitive.Portal forceMount container={container}>
+                <AlertDialogPrimitive.Overlay asChild>
+                  <OverlayPrimitive
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1, transition: { delay: DELAY } }}
+                    exit={{ opacity: 0 }}
+                  />
+                </AlertDialogPrimitive.Overlay>
+                <ContentPrimitive
+                  {...props}
+                  ref={forwardedRef}
+                  forceMount
+                  asChild
                 >
-                  <Title>{title}</Title>
-                  {description && <Description>{description}</Description>}
-                  <ButtonContainer>
-                    <AlertDialogPrimitive.Cancel asChild>
-                      <CancelButton onClick={onCancelClick}>
-                        {cancelText}
-                      </CancelButton>
-                    </AlertDialogPrimitive.Cancel>
-                    <AlertDialogPrimitive.Action asChild>
-                      <ConfirmButton onClick={onConfirmClick}>
-                        {confirmText}
-                      </ConfirmButton>
-                    </AlertDialogPrimitive.Action>
-                    {showAddtlAction && (
+                  <Content
+                    initial={{ scale: 0 }}
+                    animate={{ scale: 1, transition: { delay: DELAY } }}
+                    exit={{ scale: 0 }}
+                  >
+                    <Title>{title}</Title>
+                    {description && <Description>{description}</Description>}
+                    <ButtonContainer>
+                      <AlertDialogPrimitive.Cancel asChild>
+                        <CancelButton onClick={onCancelClick}>
+                          {cancelText}
+                        </CancelButton>
+                      </AlertDialogPrimitive.Cancel>
                       <AlertDialogPrimitive.Action asChild>
-                        <MiscButton onClick={onAddtlActionClick}>
-                          {addtlActionText}
-                        </MiscButton>
+                        <ConfirmButton onClick={onConfirmClick}>
+                          {confirmText}
+                        </ConfirmButton>
                       </AlertDialogPrimitive.Action>
-                    )}
-                  </ButtonContainer>
-                </Content>
-              </ContentPrimitive>
-            </AlertDialogPrimitive.Portal>
+                      {showAddtlAction && (
+                        <AlertDialogPrimitive.Action asChild>
+                          <MiscButton onClick={onAddtlActionClick}>
+                            {addtlActionText}
+                          </MiscButton>
+                        </AlertDialogPrimitive.Action>
+                      )}
+                    </ButtonContainer>
+                  </Content>
+                </ContentPrimitive>
+              </AlertDialogPrimitive.Portal>
+              <PortalContainer
+                id="alert-modal-portal-root"
+                ref={portalContainerRef}
+              />
+            </>
           )}
         </AnimatePresence>
-        <PortalContainer id="alert-modal-portal-root" ref={setContainer} />
       </>
     );
   }

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useState } from "react";
+import { forwardRef, useEffect, useRef, useState } from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { AnimatePresence, motion } from "framer-motion";
 import SvgIcon from "../SvgIcon/SvgIcon";
@@ -83,38 +83,54 @@ type ContentProps = {
 
 export const ModalContent = forwardRef<ContentRef, ContentProps>(
   ({ children, title, description, isOpen, ...props }, forwardedRef) => {
-    const [container, setContainer] = useState<HTMLDivElement | null>(null);
+    const [portalContainer, setPortalContainer] =
+      useState<HTMLDivElement | null>(null);
+    const portalContainerRef = useRef<HTMLDivElement | null>(null);
+
+    useEffect(() => {
+      setPortalContainer(portalContainerRef.current);
+    }, []);
+
     return (
       <>
         <AnimatePresence>
           {isOpen && (
-            <DialogPrimitive.Portal forceMount container={container}>
-              <OverlayPrimitive />
-              <ContentPrimitive
-                {...props}
-                ref={forwardedRef}
-                forceMount
-                asChild
-              >
-                <Content
-                  initial={{ scale: 0 }}
-                  animate={{ scale: 1 }}
-                  exit={{ scale: 0 }}
+            <>
+              <DialogPrimitive.Portal forceMount container={portalContainer}>
+                <OverlayPrimitive />
+                <ContentPrimitive
+                  {...props}
+                  ref={forwardedRef}
+                  forceMount
+                  asChild
                 >
-                  <TitleBar>
-                    <Title>{title}</Title>
-                    <ClosePrimitive aria-label="Close">
-                      <SvgIcon icon={<CloseIcon />} width="2em" height="2em" />
-                    </ClosePrimitive>
-                  </TitleBar>
-                  {description && <Description>{description}</Description>}
-                  {children}
-                </Content>
-              </ContentPrimitive>
-            </DialogPrimitive.Portal>
+                  <Content
+                    initial={{ scale: 0 }}
+                    animate={{ scale: 1 }}
+                    exit={{ scale: 0 }}
+                  >
+                    <TitleBar>
+                      <Title>{title}</Title>
+                      <ClosePrimitive aria-label="Close">
+                        <SvgIcon
+                          icon={<CloseIcon />}
+                          width="2em"
+                          height="2em"
+                        />
+                      </ClosePrimitive>
+                    </TitleBar>
+                    {description && <Description>{description}</Description>}
+                    {children}
+                  </Content>
+                </ContentPrimitive>
+              </DialogPrimitive.Portal>
+              <PortalContainer
+                id="modal-dialog-portal-root"
+                ref={portalContainerRef}
+              />
+            </>
           )}
         </AnimatePresence>
-        <PortalContainer id="modal-dialog-portal-root" ref={setContainer} />
       </>
     );
   }


### PR DESCRIPTION
Accounts for an issue with radix-ui modals/dialogs where the portals weren't being removed from the page, causing user to be unable to interact with page even when component unmounts