### PR TITLE
Updated Android Screen Resize Method

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
-            android:windowSoftInputMode="adjustPan"
+            android:windowSoftInputMode="adjustResize"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode"
             android:name=".MainActivity"
             android:label="@string/title_activity_main"


### PR DESCRIPTION
## Bug Fixes
- Resize method for Android updated from `adjustPan` to `adjustResize` so that contents don't become covered by virtual keyboard
**Note:** the floating tab bar looks a bit strange on virtual keyboard open, moves above keyboard. Ideally would hide it while keyboard is open