### PR TITLE
Fix for #204: doesn't honor batch size if cards are less than batch size

### DIFF
--- a/src/components/BasicAssignmentSettings/BasicAssignmentSettings.tsx
+++ b/src/components/BasicAssignmentSettings/BasicAssignmentSettings.tsx
@@ -56,12 +56,16 @@ function BasicAssignmentSettings({
     defaultBatchSize === "All"
       ? assignmentData.length
       : parseInt(defaultBatchSize);
-  const selectedBatchSize = (
+  let selectedBatchSize = (
     defaultBatchSizeNum <= assignmentData.length
       ? defaultBatchSize
       : Math.max(...batchSizeNumbers)
   ) as string;
 
+  // If the selectedBatchSize batch size is smaller than the preffered batch size, set the batch size to "All"
+  if (parseInt(selectedBatchSize) < defaultBatchSizeNum) {
+    selectedBatchSize = "All";
+  }
   return (
     <Card>
       <SettingOptionContainer>


### PR DESCRIPTION
Just set to All if the number remain is less than the preferred amount