### PR TITLE
Fix iOS Build Workflow

### DIFF
--- a/.github/workflows/build-ios-app.yml
+++ b/.github/workflows/build-ios-app.yml
@@ -46,7 +46,7 @@ jobs:
           APP_STORE_CONNECT_TEAM_ID: ${{ secrets.APP_STORE_CONNECT_TEAM_ID }}
           DEVELOPER_PORTAL_TEAM_ID: ${{ secrets.DEVELOPER_PORTAL_TEAM_ID }}
       - name: Upload iOS release bundle
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ios-release
           path: ./App.ipa

--- a/.github/workflows/build-ios-app.yml
+++ b/.github/workflows/build-ios-app.yml
@@ -38,7 +38,7 @@ jobs:
           APPLE_KEY_CONTENT: ${{ secrets.APPLE_KEY_CONTENT }}
           CERTIFICATE_STORE_URL: https://github.com/${{ secrets.CERTIFICATE_STORE_REPO }}.git
           GIT_USERNAME: ${{ secrets.GIT_USERNAME }}
-          GIT_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          GIT_TOKEN: ${{ secrets.GIT_TOKEN }}
           FASTLANE_APPLE_ID: ${{ secrets.FASTLANE_APPLE_ID }}
           FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: ${{ secrets.FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD }}
           MATCH_USERNAME: ${{ secrets.FASTLANE_APPLE_ID }}


### PR DESCRIPTION
- Fixes accidentally using `PERSONAL_ACCESS_TOKEN` instead of `GIT_TOKEN` in workflow
- Updates upload-artifact action to v4