### PR TITLE
Account for iOS Notch/Safe Areas

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -13,6 +13,9 @@ const config: CapacitorConfig = {
       url: "http://192.168.0.23:5173",
       cleartext: true,
     },
+    ios: {
+      contentInset: "always",
+    },
   }),
 };
 

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -4,6 +4,9 @@ const baseConfig: CapacitorConfig = {
   appId: "io.hakubun.app",
   appName: "Hakubun",
   webDir: "dist",
+  ios: {
+    contentInset: "always",
+  },
 };
 
 const config: CapacitorConfig = {
@@ -12,9 +15,6 @@ const config: CapacitorConfig = {
     server: {
       url: "http://192.168.0.23:5173",
       cleartext: true,
-    },
-    ios: {
-      contentInset: "always",
     },
   }),
 };

--- a/src/components/BottomSheet/BottomSheet.tsx
+++ b/src/components/BottomSheet/BottomSheet.tsx
@@ -11,11 +11,11 @@ import styled from "styled-components";
 const Content = styled(RadixDialog.Content)`
   width: 100%;
   border-radius: 12px 12px 0 0;
-  height: 100%;
   overflow-y: clip;
   pointer-events: auto;
   position: absolute;
   background-color: var(--foreground-color);
+  bottom: 0;
   left: 0;
   right: 0;
   z-index: 12;
@@ -83,8 +83,10 @@ function BottomSheetContentCore(
 ) {
   const headerRef = useRef<HTMLDivElement | null>(null);
   const sheetContainerRef = useRef<HTMLDivElement | null>(null);
-  const bottomSheetHeight = "85svh";
-  const headerHeight = "12svh";
+  // const bottomSheetHeight = "85svh";
+  // const headerHeight = "12svh";
+  const bottomSheetHeight = "85dvh";
+  const headerHeight = "12dvh";
 
   const sheetPosVariants = {
     fullyOpen: { y: 0 },

--- a/src/components/BottomSheet/BottomSheet.tsx
+++ b/src/components/BottomSheet/BottomSheet.tsx
@@ -83,8 +83,6 @@ function BottomSheetContentCore(
 ) {
   const headerRef = useRef<HTMLDivElement | null>(null);
   const sheetContainerRef = useRef<HTMLDivElement | null>(null);
-  // const bottomSheetHeight = "85svh";
-  // const headerHeight = "12svh";
   const bottomSheetHeight = "85dvh";
   const headerHeight = "12dvh";
 

--- a/src/components/RootContainer/RootContainer.tsx
+++ b/src/components/RootContainer/RootContainer.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useLocation, useOutlet } from "react-router";
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, motion, useWillChange } from "framer-motion";
 import useAssignmentQueueStoreFacade from "../../stores/useAssignmentQueueStore/useAssignmentQueueStore.facade";
 import FloatingTabBar from "../FloatingTabBar";
 import styled from "styled-components";
@@ -14,7 +14,7 @@ const containerVariants = {
 const PageContainer = styled(motion.div)`
   display: grid;
   grid-template-rows: auto 1fr auto;
-  min-height: 100%;
+  min-height: 100dvh;
   position: relative;
   background-size: cover;
   background-color: var(--background-color);
@@ -32,6 +32,7 @@ function RootContainer() {
   const routerLocation = useLocation();
   const { sessionInProgress: isSessionInProgress } =
     useAssignmentQueueStoreFacade();
+  const willChange = useWillChange();
 
   const pgsToShowTabBar = ["/", "/search", "/subjects"];
   const subjectDetailsPgRegex = /\/subjects\/\d+/;
@@ -51,6 +52,7 @@ function RootContainer() {
           exit="out"
           variants={containerVariants}
           transition={{ duration: 0.5, delay: 0.1 }}
+          style={{ willChange }}
         >
           <AnimatedOutlet />
         </PageContainer>

--- a/src/pages/Subjects.tsx
+++ b/src/pages/Subjects.tsx
@@ -19,11 +19,7 @@ const HeaderAndTabsContainer = styled.div<HeaderAndTabsContainerProps>`
   display: grid;
   grid-template-rows: auto 1fr;
   height: 100%;
-  padding-bottom: ${({ $tabBarHeight }) =>
-    `calc(${$tabBarHeight} + 30px + constant(safe-area-inset-bottom))`};
-
-  padding-bottom: ${({ $tabBarHeight }) =>
-    `calc(${$tabBarHeight} + 30px + env(safe-area-inset-bottom))`};
+  padding-bottom: ${({ $tabBarHeight }) => `calc(${$tabBarHeight} + 30px)`};
 `;
 
 const SubjectsHeader = styled(Header)`

--- a/src/theme/globals.scss
+++ b/src/theme/globals.scss
@@ -10,11 +10,6 @@ body {
 
   ion-app {
     overflow: -moz-hidden-unscrollable !important;
-    margin-top: constant(safe-area-inset-top);
-    margin-top: env(safe-area-inset-top);
-
-    margin-bottom: constant(safe-area-inset-bottom);
-    margin-bottom: env(safe-area-inset-bottom);
   }
 }
 
@@ -125,10 +120,6 @@ ion-toast {
 div[role="region"] {
   position: absolute;
   z-index: 2000;
-  top: constant(safe-area-inset-top);
-  top: env(safe-area-inset-top);
-  bottom: constant(safe-area-inset-bottom);
-  bottom: env(safe-area-inset-bottom);
   pointer-events: none;
   touch-action: none;
 }


### PR DESCRIPTION
Accounts for status bar/notch and bottom button **for realz** this time, tested on Browserstack device
- Uses `contentInset` set to "always" in capacitor config
- Removed uses of safe area as padding, no longer necessary