### PR TITLE
Bump Version Workflow - Version Name Input and OS Change

### DIFF
--- a/.github/workflows/bump-app-version.yml
+++ b/.github/workflows/bump-app-version.yml
@@ -4,30 +4,39 @@ on:
   push:
     branches:
       - "bump/v*.*.*"
-
+  workflow_dispatch:
+    inputs:
+      version_name:
+        description: "App version name"
+        type: string
 jobs:
   bump-version-and-open-pr:
     permissions:
       contents: write
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+      - name: Get version name from input
+        if: ${{ inputs.version_name }}
+        run: echo "VERSION_NAME=${{ inputs.version_name }}" >> $GITHUB_ENV
+
+      - name: Get version name from branch name
+        if: ${{ !inputs.version_name }}
+        run: |
+          version_name=${GITHUB_REF#refs/heads/bump/v}
+          echo "VERSION_NAME=$version_name" >> $GITHUB_ENV
 
       - name: Extract existing version code
         run: |
-          # Extract version number from branch name
-          version_name=${GITHUB_REF#refs/heads/bump/v}
-
           # Get existing Android version code from build.gradle
           version_code_android=$(grep "versionCode" android/app/build.gradle | awk '{print $2}' | tr -d '\n')
 
           # Increment existing Android version code by 1
           version_code_android=$((version_code_android + 1))
 
-          # Set environment variables for later use
-          echo "VERSION_NAME=$version_name" >> $GITHUB_ENV
+          # Set env var for later use
           echo "VERSION_CODE_ANDROID=$version_code_android" >> $GITHUB_ENV
 
       - name: Set up Ruby env


### PR DESCRIPTION
- OS changed to macos since others don't provide agvtool
- Allowing version name input to be passed in as alternative to branch name