### PR TITLE
Bump iOS Fix

### DIFF
--- a/.github/workflows/bump-app-version.yml
+++ b/.github/workflows/bump-app-version.yml
@@ -67,6 +67,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "Updating version to ${{ env.VERSION_NAME }} and incrementing build numbers"
+          file_pattern: "*.pbxproj, */build.gradle, */info.plist, */App.tsx"
 
       - name: Open pull request
         uses: peter-evans/create-pull-request@v5

--- a/.github/workflows/bump-app-version.yml
+++ b/.github/workflows/bump-app-version.yml
@@ -18,17 +18,22 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-      - name: Get version name from input
-        if: ${{ inputs.version_name }}
-        run: echo "VERSION_NAME=${{ inputs.version_name }}" >> $GITHUB_ENV
 
-      - name: Get version name from branch name
-        if: ${{ !inputs.version_name }}
+      - name: Get version name
+        id: versionname
         run: |
+          VERSION_NAME=${{ github.event.inputs.version_name }}
           version_name=${GITHUB_REF#refs/heads/bump/v}
-          echo "VERSION_NAME=$version_name" >> $GITHUB_ENV
 
-      - name: Extract existing version code
+          echo "version_output=${VERSION_NAME:-$version_name}" >> "$GITHUB_OUTPUT"
+
+      - name: Set version name
+        run: |
+          version="${{ steps.versionname.outputs.version_output }}"
+          echo "VERSION_NAME: $version"
+          echo "VERSION_NAME=${{ steps.versionname.outputs.version_output }}" >> $GITHUB_ENV
+
+      - name: Extract existing android version code
         run: |
           # Get existing Android version code from build.gradle
           version_code_android=$(grep "versionCode" android/app/build.gradle | awk '{print $2}' | tr -d '\n')
@@ -39,8 +44,14 @@ jobs:
           # Set env var for later use
           echo "VERSION_CODE_ANDROID=$version_code_android" >> $GITHUB_ENV
 
+      - name: Increment Android build number
+        run: sed -i '' "s/versionCode [0-9]\+/versionCode ${{ env.VERSION_CODE_ANDROID }}/g" android/app/build.gradle
+
+      - name: Update version for Android
+        run: sed -i '' "s/versionName \"[^\"]*\"/versionName \"${{ env.VERSION_NAME }}\"/g" android/app/build.gradle
+
       - name: Set up Ruby env
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@v1.171.0
         with:
           ruby-version: 3.3.0
           bundler-cache: true
@@ -50,12 +61,6 @@ jobs:
 
       - name: Update version name for iOS
         run: bundle exec fastlane ios set_version_number
-
-      - name: Increment Android build number
-        run: sed -i "s/versionCode [0-9]\+/versionCode ${{ env.VERSION_CODE_ANDROID }}/g" android/app/build.gradle
-
-      - name: Update version for Android
-        run: sed -i "s/versionName \"[^\"]*\"/versionName \"${{ env.VERSION_NAME }}\"/g" android/app/build.gradle
 
       - name: Commit and push changes
         uses: stefanzweifel/git-auto-commit-action@v5

--- a/.github/workflows/bump-app-version.yml
+++ b/.github/workflows/bump-app-version.yml
@@ -1,5 +1,5 @@
 # Workflow based on this article https://www.paleblueapps.com/rockandnull/github-actions-android-version/
-name: Bump version code & updates version name
+name: Bump version code & update version name
 on:
   push:
     branches:

--- a/.github/workflows/bump-app-version.yml
+++ b/.github/workflows/bump-app-version.yml
@@ -67,7 +67,6 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "Updating version to ${{ env.VERSION_NAME }} and incrementing build numbers"
-          file_pattern: "ios/**, android/**, src/**"
 
       - name: Open pull request
         uses: peter-evans/create-pull-request@v5

--- a/.github/workflows/bump-app-version.yml
+++ b/.github/workflows/bump-app-version.yml
@@ -68,6 +68,7 @@ jobs:
         with:
           commit_message: "Updating version to ${{ env.VERSION_NAME }} and incrementing build numbers"
           file_pattern: "*.pbxproj, */build.gradle, */info.plist, */App.tsx"
+          disable_globbing: true
 
       - name: Open pull request
         uses: peter-evans/create-pull-request@v5

--- a/.github/workflows/bump-app-version.yml
+++ b/.github/workflows/bump-app-version.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Get version name
-        id: versionname
+        id: versionNameStep
         run: |
           VERSION_NAME=${{ github.event.inputs.version_name }}
           version_name=${GITHUB_REF#refs/heads/bump/v}
@@ -29,9 +29,9 @@ jobs:
 
       - name: Set version name
         run: |
-          version="${{ steps.versionname.outputs.version_output }}"
+          version="${{ steps.versionNameStep.outputs.version_output }}"
           echo "VERSION_NAME: $version"
-          echo "VERSION_NAME=${{ steps.versionname.outputs.version_output }}" >> $GITHUB_ENV
+          echo "VERSION_NAME=${{ steps.versionNameStep.outputs.version_output }}" >> $GITHUB_ENV
 
       - name: Extract existing android version code
         run: |
@@ -42,10 +42,11 @@ jobs:
           version_code_android=$((version_code_android + 1))
 
           # Set env var for later use
+          # echo "VERSION_CODE_ANDROID: $version_code_android"
           echo "VERSION_CODE_ANDROID=$version_code_android" >> $GITHUB_ENV
 
       - name: Increment Android build number
-        run: sed -i '' "s/versionCode [0-9]\+/versionCode ${{ env.VERSION_CODE_ANDROID }}/g" android/app/build.gradle
+        run: sed -i '' 's/versionCode [0-9]*/versionCode ${{ env.VERSION_CODE_ANDROID }}/g' android/app/build.gradle
 
       - name: Update version for Android
         run: sed -i '' "s/versionName \"[^\"]*\"/versionName \"${{ env.VERSION_NAME }}\"/g" android/app/build.gradle

--- a/.github/workflows/bump-app-version.yml
+++ b/.github/workflows/bump-app-version.yml
@@ -67,15 +67,14 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "Updating version to ${{ env.VERSION_NAME }} and incrementing build numbers"
-          file_pattern: "*.pbxproj, */build.gradle, */info.plist, */App.tsx"
-          disable_globbing: true
+          file_pattern: "ios/**, android/**, src/**"
 
       - name: Open pull request
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.PAT_W_WORKFLOW_TRIGGER }}
-          commit-message: "Incrementing version to ${{ env.VERSION_NAME }}, Android version code to ${{ env.VERSION_CODE }}"
+          commit-message: "Incrementing version to ${{ env.VERSION_NAME }}, bumping iOS and Android build numbers"
           branch: "${{ github.ref }}"
-          title: "Bump App to Version ${{ env.VERSION_NAME }}, Android version code ${{ env.VERSION_CODE }}"
-          body: "App version name updated to ${{ env.VERSION_NAME }} and Android version code set to ${{ env.VERSION_CODE }}"
+          title: "Bump App to Version ${{ env.VERSION_NAME }}"
+          body: "App version name updated to ${{ env.VERSION_NAME }} and build numbers incremented"
           base: "main"

--- a/.gitignore
+++ b/.gitignore
@@ -62,5 +62,5 @@ keystore.jks
 **/fastlane/report.xml
 
 # Ruby and bundle
-**/vendor/bundle/ruby/*
+*/vendor/bundle/ruby/*
 .bundle/*

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,7 @@ keystore.jks
 
 # Fastlane
 **/fastlane/report.xml
+
+# Ruby and bundle
+**/vendor/bundle/ruby/*
+.bundle/*

--- a/.gitignore
+++ b/.gitignore
@@ -62,5 +62,5 @@ keystore.jks
 **/fastlane/report.xml
 
 # Ruby and bundle
-*/vendor/bundle/ruby/*
+vendor/bundle/ruby/*
 .bundle/*

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -68,12 +68,14 @@ platform :ios do
     end
 
     lane :bump do
+        skip_docs
         increment_build_number(
             xcodeproj: File.join(ios_dir, "App/App.xcodeproj"),
         )
     end
 
     lane :set_version_number do
+        skip_docs
         increment_version_number(
             version_number: "#{VERSION_NAME}",
             xcodeproj: File.join(ios_dir, "App/App.xcodeproj"),


### PR DESCRIPTION
- Bumps/increments iOS version
- Updates iOS version name
- Avoids committing a bunch of vendor files
- sed command updated to work with macOS
- Docs generation is skipped when bumping and updating version name