### PR TITLE
Bump App Version - Branch Creation and Checkout

### DIFF
--- a/.github/workflows/bump-app-version.yml
+++ b/.github/workflows/bump-app-version.yml
@@ -71,7 +71,22 @@ jobs:
       - name: Update version name for iOS
         run: bundle exec fastlane ios set_version_number
 
+      - name: Commit and push changes if workflow_dispatch
+        uses: stefanzweifel/git-auto-commit-action@v5
+        if: github.event_name == 'workflow_dispatch'
+        with:
+          commit_message: "Updating version to ${{ env.VERSION_NAME }} and incrementing build numbers"
+          create_branch: true
+          branch: "bump/v${{ env.VERSION_NAME }}"
+
+      - name: Checkout created branch if workflow_dispatch
+        uses: actions/checkout@v4
+        if: github.event_name == 'workflow_dispatch'
+        with:
+          ref: "bump/v${{ env.VERSION_NAME }}"
+
       - name: Commit and push changes
+        if: github.event_name == 'pull_request'
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "Updating version to ${{ env.VERSION_NAME }} and incrementing build numbers"


### PR DESCRIPTION
Accounting for when `workflow_dispatch` event instead of on bump branch
- Create and checkout branch if on main when workflow runs