### PR TITLE
Generate Changelog on App Version Update

### DIFF
--- a/.github/config/changelog-config.json
+++ b/.github/config/changelog-config.json
@@ -1,5 +1,5 @@
 {
-  "ignore_labels": ["ignore-in-changelog", "bump version"],
+  "ignore_labels": ["ignore in changelog", "bump version"],
   "template": "Changelog for #{{TO_TAG}}\n\n#{{CHANGELOG}}",
   "pr_template": "- #{{TITLE}}\n\t- Author: #{{AUTHOR}}",
   "categories": [

--- a/.github/config/changelog-config.json
+++ b/.github/config/changelog-config.json
@@ -1,0 +1,26 @@
+{
+  "ignore_labels": ["ignore-in-changelog", "bump version"],
+  "template": "Changelog for ${{ inputs.versionName }}\n\n #{{CHANGELOG}}",
+  "categories": [
+    {
+      "title": "Features/Enhancements",
+      "labels": ["enhancement", "feature"]
+    },
+    {
+      "title": "Bug Fixes",
+      "labels": ["bug"]
+    },
+    {
+      "title": "Refactor",
+      "labels": ["refactor"]
+    },
+    {
+      "title": "Dependencies",
+      "labels": ["dependencies"]
+    },
+    {
+      "title": "Other",
+      "labels": ["styling", "documentation", "cicd"]
+    }
+  ]
+}

--- a/.github/config/changelog-config.json
+++ b/.github/config/changelog-config.json
@@ -1,6 +1,7 @@
 {
   "ignore_labels": ["ignore-in-changelog", "bump version"],
-  "template": "Changelog for ${{ inputs.versionName }}\n\n #{{CHANGELOG}}",
+  "template": "Changelog for #{{TO_TAG}}\n\n#{{CHANGELOG}}",
+  "pr_template": "- #{{TITLE}}\n\t- Author: #{{AUTHOR}}",
   "categories": [
     {
       "title": "Features/Enhancements",
@@ -20,7 +21,7 @@
     },
     {
       "title": "Other",
-      "labels": ["styling", "documentation", "cicd"]
+      "labels": ["styling", "documentation", "cicd", "testing"]
     }
   ]
 }

--- a/.github/workflows/bump-app-version.yml
+++ b/.github/workflows/bump-app-version.yml
@@ -45,7 +45,7 @@ jobs:
         run: sed -i '' "s/versionName \"[^\"]*\"/versionName \"${{ inputs.versionName }}\"/g" android/app/build.gradle
 
       - name: Set up Ruby env
-        uses: ruby/setup-ruby@v1.171.0
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.3.0
           bundler-cache: true
@@ -55,6 +55,27 @@ jobs:
 
       - name: Update version name for iOS
         run: bundle exec fastlane ios set_version_number version:${{ inputs.versionName }}
+
+      # TODO: remove ls, change from temp.txt to {BUILD_NUMBER}
+      - name: Create file for changelog
+        run: |
+          ls
+          touch ./fastlane/metadata/android/en-US/changelogs/temp.txt
+
+      - name: Generate changelog
+        uses: mikepenz/release-changelog-builder-action@v4
+        with:
+          #   fromTag: "${{ steps.get-prev-tag.outputs.previous-tag }}"
+          #   fromTag: ${{ steps.previoustag.outputs.tag }}
+          #   toTag: "HEAD"
+          #   toTag: ${{ github.ref }}
+          #   toTag: "${{ steps.get-prev-tag.outputs.new-tag }}"
+          # toTag: "${{ steps.get-new-tag.outputs.new-tag }}"
+          configuration: ".github/config/changelog-config.json"
+          # TODO: change so outputs to fastlane/metadata/android/en-US/changelogs/{BUILD_NUMBER}.txt
+          outputFile: fastlane/metadata/android/en-US/changelogs/temp.txt
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Open pull request
         uses: peter-evans/create-pull-request@v5

--- a/.github/workflows/bump-app-version.yml
+++ b/.github/workflows/bump-app-version.yml
@@ -70,7 +70,7 @@ jobs:
           token: ${{ secrets.PAT_W_WORKFLOW_TRIGGER }}
           commit-message: "Incrementing version to ${{ inputs.versionName }}, bumping iOS and Android build numbers"
           branch: bump/v${{ inputs.versionName }}
-          title: "Bump App to Version ${{ inputs.versionName }}"
+          title: "App Version Updated to ${{ inputs.versionName }}"
           body: "App version name updated to ${{ inputs.versionName }} and build numbers incremented"
           base: "main"
           labels: "bump version"

--- a/.github/workflows/bump-app-version.yml
+++ b/.github/workflows/bump-app-version.yml
@@ -56,13 +56,6 @@ jobs:
       - name: Update version name for iOS
         run: bundle exec fastlane ios set_version_number version:${{ inputs.versionName }}
 
-      - name: Commit and push changes
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          branch: bump/v${{ inputs.versionName }}
-          create_branch: true
-          commit_message: "Updating version to ${{ inputs.versionName }} and incrementing build numbers"
-
       - name: Open pull request
         uses: peter-evans/create-pull-request@v5
         with:

--- a/.github/workflows/bump-app-version.yml
+++ b/.github/workflows/bump-app-version.yml
@@ -68,7 +68,7 @@ jobs:
         with:
           token: ${{ secrets.PAT_W_WORKFLOW_TRIGGER }}
           commit-message: "Incrementing version to ${{ inputs.versionName }}, bumping iOS and Android build numbers"
-          branch: "${{ github.ref }}"
+          branch: bump/v${{ inputs.versionName }}
           title: "Bump App to Version ${{ inputs.versionName }}"
           body: "App version name updated to ${{ inputs.versionName }} and build numbers incremented"
           base: "main"

--- a/.github/workflows/bump-app-version.yml
+++ b/.github/workflows/bump-app-version.yml
@@ -56,24 +56,11 @@ jobs:
       - name: Update version name for iOS
         run: bundle exec fastlane ios set_version_number version:${{ inputs.versionName }}
 
-      # TODO: remove ls, change from temp.txt to {BUILD_NUMBER}
-      - name: Create file for changelog
-        run: |
-          ls
-          touch ./fastlane/metadata/android/en-US/changelogs/temp.txt
-
       - name: Generate changelog
         uses: mikepenz/release-changelog-builder-action@v4
         with:
-          #   fromTag: "${{ steps.get-prev-tag.outputs.previous-tag }}"
-          #   fromTag: ${{ steps.previoustag.outputs.tag }}
-          #   toTag: "HEAD"
-          #   toTag: ${{ github.ref }}
-          #   toTag: "${{ steps.get-prev-tag.outputs.new-tag }}"
-          # toTag: "${{ steps.get-new-tag.outputs.new-tag }}"
           configuration: ".github/config/changelog-config.json"
-          # TODO: change so outputs to fastlane/metadata/android/en-US/changelogs/{BUILD_NUMBER}.txt
-          outputFile: fastlane/metadata/android/en-US/changelogs/temp.txt
+          outputFile: fastlane/metadata/android/en-US/changelogs/${{ steps.get-android-build-number.outputs.versionCodeAndroid }}.txt
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -100,6 +100,7 @@ platform :ios do
             )
     end
 
+    # TODO: pass changelog as parameter
     lane :upload_beta do
         build_beta
         upload_to_testflight(

--- a/fastlane/metadata/android/en-US/changelogs/default.txt
+++ b/fastlane/metadata/android/en-US/changelogs/default.txt
@@ -1,0 +1,1 @@
+Something went wrong with the changelog!


### PR DESCRIPTION
- Template used to generate text file changelog
- Changelog is sent to file with file name of newest Android build number
  - Uses defined Fastlane metadata file structure see [Changelogs section](https://docs.fastlane.tools/actions/upload_to_play_store/) in Fastlane docs