### PR TITLE
Prevent Alt Meaning Modal Close on Outside Click, Increase "Add" Button Size

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,23 +1,17 @@
-import { CSSProperties, useRef } from "react";
-import { useButton } from "react-aria";
+import { CSSProperties, forwardRef } from "react";
+import { useButton, useObjectRef } from "react-aria";
 import { AriaButtonProps } from "@react-types/button";
 import styled from "styled-components";
 
 type ButtonContainerProps = {
-  isPressed: boolean;
-  backgroundcolor: string;
-  color: string;
+  backgroundcolor?: string;
+  color?: string;
 };
 
 const ButtonContainer = styled.button<ButtonContainerProps>`
-  background-color: ${({ backgroundcolor }) => `${backgroundcolor}`};
-  color: ${({ color }) => `${color}`};
-  cursor: pointer;
-
-  &:focus-visible {
-    outline: 2px solid var(--focus-color);
-    outline-offset: 2px;
-  }
+  background-color: ${({ backgroundcolor }) =>
+    backgroundcolor ? `${backgroundcolor}` : "var(--button-color)"};
+  color: ${({ color }) => (color ? `${color}` : "var(--text-color)")};
 `;
 
 interface Props extends AriaButtonProps {
@@ -28,39 +22,43 @@ interface Props extends AriaButtonProps {
   disabled?: boolean;
 }
 
-function Button({
-  backgroundColor = "var(--ion-color-primary)",
-  color = "white",
-  className,
-  style,
-  disabled,
-  ...props
-}: Props) {
-  const { children } = props;
-  const ref = useRef(null);
-  const { buttonProps, isPressed } = useButton(
+const Button = forwardRef<HTMLButtonElement, Props>(
+  (
     {
-      ...props,
-      elementType: "button",
+      backgroundColor = "var(--button-color)",
+      color = "var(--text-color)",
+      className,
+      style,
+      disabled,
+      ...props
     },
-    ref
-  );
+    forwardedRef
+  ) => {
+    const { children } = props;
+    const ref = useObjectRef(forwardedRef);
+    const { buttonProps } = useButton(
+      {
+        ...props,
+        elementType: "button",
+      },
+      ref
+    );
 
-  return (
-    <ButtonContainer
-      backgroundcolor={backgroundColor}
-      color={color}
-      {...buttonProps}
-      ref={ref}
-      isPressed={isPressed}
-      tabIndex={0}
-      className={className}
-      style={style}
-      disabled={disabled}
-    >
-      {children}
-    </ButtonContainer>
-  );
-}
+    return (
+      <ButtonContainer
+        backgroundcolor={backgroundColor}
+        color={color}
+        {...buttonProps}
+        ref={ref}
+        tabIndex={0}
+        className={className}
+        style={style}
+        disabled={disabled}
+      >
+        {children}
+      </ButtonContainer>
+    );
+  }
+);
 
 export default Button;

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -7,13 +7,14 @@ type LabelStyledProps = {
   labelfontsize: string;
   color: string;
   $isBold: boolean;
+  $isHidden: boolean;
 };
 
 const LabelStyled = styled(LabelPrimitive.Root)<LabelStyledProps>`
   font-size: ${({ labelfontsize }) => `${labelfontsize}`};
   color: ${({ color }) => `${color}`};
   font-weight: ${({ $isBold }) => $isBold && 600};
-  display: block;
+  display: ${({ $isHidden }) => ($isHidden ? "none" : "block")};
 `;
 
 type LabelContents = {
@@ -21,6 +22,7 @@ type LabelContents = {
   labelfontSize?: string;
   isBold?: boolean;
   color?: string;
+  hidden?: boolean;
   children: React.ReactNode;
   labelText: string;
 };
@@ -33,6 +35,7 @@ function Label({
   labelfontSize = "1.2rem",
   color = "var(--text-color)",
   isBold = false,
+  hidden = false,
   labelText,
   children,
 }: LabelProps) {
@@ -42,6 +45,8 @@ function Label({
       labelfontsize={labelfontSize}
       color={color}
       $isBold={isBold}
+      $isHidden={hidden}
+      hidden={hidden}
     >
       {children || labelText}
     </LabelStyled>

--- a/src/components/LessonsButton/LessonsButton.tsx
+++ b/src/components/LessonsButton/LessonsButton.tsx
@@ -12,10 +12,6 @@ import {
 } from "../../styles/SubjectButtonsStyled";
 import styled from "styled-components";
 
-const LessonsButtonStyled = styled(BaseReviewLessonButton)`
-  background-color: var(--wanikani-lesson);
-`;
-
 const LessonButtonSkeleton = styled(BaseReviewLessonButtonSkeleton)`
   --background: var(--wani-kani-pink-rgba);
   --background-rgb: var(--wani-kani-pink-rgb);
@@ -50,7 +46,7 @@ function LessonsButton() {
   }
 
   const onLessonBtnClick = () => {
-    let paidSubscription = userInfo && userInfo.subscription.type !== "free";
+    const paidSubscription = userInfo && userInfo.subscription.type !== "free";
     if (lessonsData === undefined || lessonsData.length === 0) {
       displayToast({
         title: "No lessons available!",
@@ -77,8 +73,10 @@ function LessonsButton() {
 
   return (
     <>
-      <LessonsButtonStyled
+      <BaseReviewLessonButton
+        backgroundColor="var(--wanikani-lesson)"
         aria-label="Lessons"
+        className="base-button"
         onPress={onLessonBtnClick}
         style={{
           backgroundImage: `url(${setBtnBackground({
@@ -91,7 +89,7 @@ function LessonsButton() {
         <BaseReviewLessonButtonBadge>
           {lessonsData ? lessonsData.length : 0}
         </BaseReviewLessonButtonBadge>
-      </LessonsButtonStyled>
+      </BaseReviewLessonButton>
     </>
   );
 }

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -64,11 +64,21 @@ type ContentProps = {
   children: React.ReactNode;
   isOpen: boolean;
   icon?: React.ReactNode;
+  closeOnOutsidePress?: boolean;
 };
 
 export const ModalContent = forwardRef<ContentRef, ContentProps>(
   (
-    { modalID, children, title, description, isOpen, icon, ...props },
+    {
+      modalID,
+      children,
+      title,
+      description,
+      isOpen,
+      icon,
+      closeOnOutsidePress = true,
+      ...props
+    },
     forwardedRef
   ) => {
     const { modalContainerRef } = useModalContainer(modalID, isOpen);
@@ -94,6 +104,12 @@ export const ModalContent = forwardRef<ContentRef, ContentProps>(
                   ref={forwardedRef}
                   forceMount
                   asChild
+                  onPointerDownOutside={(event) => {
+                    !closeOnOutsidePress && event.preventDefault();
+                  }}
+                  onInteractOutside={(event) => {
+                    !closeOnOutsidePress && event.preventDefault();
+                  }}
                 >
                   <Content
                     initial={{ scale: 0 }}
@@ -110,8 +126,8 @@ export const ModalContent = forwardRef<ContentRef, ContentProps>(
                       <ClosePrimitive aria-label="Close">
                         <SvgIcon
                           icon={<CloseIcon />}
-                          width="2em"
-                          height="2em"
+                          width="2.5em"
+                          height="2.5em"
                         />
                       </ClosePrimitive>
                     </TitleBar>

--- a/src/components/ReviewsButton/ReviewsButton.tsx
+++ b/src/components/ReviewsButton/ReviewsButton.tsx
@@ -11,10 +11,6 @@ import {
 } from "../../styles/SubjectButtonsStyled";
 import styled from "styled-components";
 
-const ReviewsButtonStyled = styled(BaseReviewLessonButton)`
-  background-color: var(--wanikani-review);
-`;
-
 const ReviewsButtonSkeleton = styled(BaseReviewLessonButtonSkeleton)`
   --background: var(--wanikani-blue-rgba);
   --background-rgb: var(--wanikani-blue-rgb);
@@ -65,7 +61,8 @@ function ReviewsButton() {
   // TODO: delay loading until image is set
   return (
     <>
-      <ReviewsButtonStyled
+      <BaseReviewLessonButton
+        backgroundColor="var(--wanikani-review)"
         aria-label="Reviews"
         onPress={onReviewBtnClick}
         style={{
@@ -79,7 +76,7 @@ function ReviewsButton() {
         <BaseReviewLessonButtonBadge>
           {availForReviewData ? availForReviewData.length : 0}
         </BaseReviewLessonButtonBadge>
-      </ReviewsButtonStyled>
+      </BaseReviewLessonButton>
     </>
   );
 }

--- a/src/components/SubjectMeanings/AddAltUserMeaningButton.tsx
+++ b/src/components/SubjectMeanings/AddAltUserMeaningButton.tsx
@@ -15,12 +15,12 @@ const PlusSign = styled.span`
   padding-left: 5px;
 `;
 
-const AddButton = styled(Modal.Trigger)`
+const AddButton = styled.button`
   display: flex;
   align-items: center;
   padding: 8px;
-  background-color: var(--ion-color-secondary);
   border-radius: 16px;
+  border: 2px solid black;
   font-size: 0.9rem;
   color: white;
 
@@ -32,12 +32,6 @@ const AddButton = styled(Modal.Trigger)`
   &:focus-visible {
     outline: 2px solid var(--focus-color);
     outline-offset: 2px;
-  }
-
-  ion-icon {
-    margin-left: 5px;
-    width: 1.25em;
-    height: 1.25em;
   }
 `;
 
@@ -69,6 +63,7 @@ const SubmitButton = styled(Button)`
   padding: 10px;
   border-radius: 12px;
   border: 1px solid black;
+  font-size: 1.25rem;
 `;
 
 type Props = {
@@ -115,22 +110,24 @@ function AddAltUserMeaningButton({ subject }: Props) {
       {!studyMaterialLoading ? (
         <>
           <Modal onOpenChange={setIsModalOpen} open={isModalOpen}>
-            <AddButton aria-label="Add alternative meaning">
-              Add <PlusSign>+</PlusSign>
-            </AddButton>
+            <Modal.Trigger aria-label="Add alternative meaning" asChild>
+              <AddButton className="base-button">
+                Add <PlusSign>+</PlusSign>
+              </AddButton>
+            </Modal.Trigger>
             <Modal.Content
               modalID="add-alt-user-meaning-modal"
               title="Add Meaning"
               isOpen={isModalOpen}
-              description="Add an alternative meaning, these will be accepted as correct answers!"
+              description="Add an alternative meaning, this will be accepted as a correct answer!"
+              closeOnOutsidePress={false}
             >
               <MeaningForm onSubmit={handleSubmit}>
                 <Fieldset>
                   <Label
-                    labelfontSize="1rem"
-                    isBold={true}
                     labelText="Meaning"
                     idOfControl="alt-user-meaning-input"
+                    hidden={true}
                   />
                   <MeaningInput
                     ref={inputRef}
@@ -141,6 +138,7 @@ function AddAltUserMeaningButton({ subject }: Props) {
                 </Fieldset>
                 <ButtonContainer>
                   <SubmitButton
+                    className="base-button"
                     type="submit"
                     backgroundColor="var(--ion-color-tertiary)"
                     color="black"

--- a/src/components/UserNote/EditNoteModal.tsx
+++ b/src/components/UserNote/EditNoteModal.tsx
@@ -15,11 +15,10 @@ const AddButtonContainer = styled.div`
   margin-top: 10px;
 `;
 
-const AddButton = styled(Modal.Trigger)`
+const AddButton = styled.button`
   display: flex;
   align-items: center;
   padding: 8px;
-  background-color: var(--ion-color-secondary);
   border: 2px solid black;
   border-radius: 16px;
   font-size: 0.9rem;
@@ -74,6 +73,7 @@ const SubmitButton = styled(Button)`
   padding: 10px;
   border-radius: 12px;
   border: 1px solid black;
+  font-size: 1.25rem;
 `;
 
 const PlusSign = styled.span`
@@ -153,10 +153,12 @@ function EditNoteModal({
     <Modal onOpenChange={setIsOpen} open={isOpen}>
       {isAddBtnVisible && (
         <AddButtonContainer>
-          <AddButton aria-label={`Add ${noteType} note`}>
-            {addButtonTxt}
-            <PlusSign>+</PlusSign>
-          </AddButton>
+          <Modal.Trigger aria-label={`Add ${noteType} note`} asChild>
+            <AddButton className="base-button">
+              {addButtonTxt}
+              <PlusSign>+</PlusSign>
+            </AddButton>
+          </Modal.Trigger>
         </AddButtonContainer>
       )}
       <Modal.Content
@@ -165,6 +167,7 @@ function EditNoteModal({
         isOpen={isOpen}
         description={`Come up with a note that helps you remember the ${noteType}!`}
         icon={noteType === "meaning" ? <MeaningIcon /> : <ReadingIcon />}
+        closeOnOutsidePress={false}
       >
         <UserNoteForm onSubmit={handleSubmit}>
           <Fieldset>
@@ -177,6 +180,7 @@ function EditNoteModal({
           </Fieldset>
           <ButtonContainer>
             <SubmitButton
+              className="base-button"
               type="submit"
               backgroundColor="var(--ion-color-tertiary)"
               color="black"

--- a/src/styles/BaseStyledComponents.tsx
+++ b/src/styles/BaseStyledComponents.tsx
@@ -123,25 +123,6 @@ export const BottomSheetContent = styled(IonRow)`
   padding-bottom: var(--ion-padding, 16px);
 `;
 
-type ButtonContainerProps = {
-  isPressed: boolean;
-  backgroundcolor: string;
-  color: string;
-};
-
-export const BaseButton = styled.button<ButtonContainerProps>`
-  cursor: pointer;
-  user-select: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-
-  &:focus-visible {
-    outline: 2px solid var(--focus-color);
-    outline-offset: 2px;
-  }
-`;
-
 export const FloatingButton = styled(Button)`
   user-select: none;
   -webkit-user-select: none;

--- a/src/theme/globals.scss
+++ b/src/theme/globals.scss
@@ -144,3 +144,17 @@ ion-toast.custom-toast.warning-toast {
     font-size: 15px;
   }
 }
+
+.base-button {
+  background-color: var(--button-color);
+  color: var(--text-color);
+  cursor: pointer;
+
+  border: 1px solid black;
+  box-shadow: #000 2px 2px 0 0;
+
+  &:focus-visible {
+    outline: 2px solid var(--focus-color);
+    outline-offset: 2px;
+  }
+}

--- a/src/theme/variables.css
+++ b/src/theme/variables.css
@@ -145,6 +145,7 @@ http://ionicframework.com/docs/theming/ */
   --box-shadow-color: var(--pale-grey);
   --contrast-color: var(--light-grey);
   --text-color: black;
+  --button-color: var(--ion-color-primary);
   --contrast-text-color: white;
   --link-text-color: var(--ion-color-secondary-darkest);
   --focus-color: black;
@@ -195,6 +196,7 @@ http://ionicframework.com/docs/theming/ */
     --contrast-color: var(--offwhite-color);
     --box-shadow-color: var(--darkest-purple);
     --text-color: white;
+    --button-color: var(--ion-color-secondary);
     --link-text-color: var(--ion-color-primary-tint);
     --contrast-text-color: black;
     --focus-color: white;


### PR DESCRIPTION
Modal to add alternative meanings would close on outside click, causing users to think they added a meaning when they were slightly off trying to press the "Add" button

- Modal no longer closes unless close button or keyboard esc are pressed
- Increased size of "Add" button font size in modal
- Buttons styles improved to look more _button-y_
- Correctly using `useObjectRef` for react-aria button