### PR TITLE
Deploy iOS Beta App Workflow Fixes

### DIFF
--- a/.github/workflows/build-ios-app.yml
+++ b/.github/workflows/build-ios-app.yml
@@ -41,10 +41,13 @@ jobs:
           GIT_TOKEN: ${{ secrets.GIT_TOKEN }}
           FASTLANE_APPLE_ID: ${{ secrets.FASTLANE_APPLE_ID }}
           FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: ${{ secrets.FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD }}
+          FASTLANE_USER: ${{ secrets.FASTLANE_USER }}
           MATCH_USERNAME: ${{ secrets.FASTLANE_APPLE_ID }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           APP_STORE_CONNECT_TEAM_ID: ${{ secrets.APP_STORE_CONNECT_TEAM_ID }}
           DEVELOPER_PORTAL_TEAM_ID: ${{ secrets.DEVELOPER_PORTAL_TEAM_ID }}
+          MATCH_KEYCHAIN_PASSWORD: ${{ secrets.MATCH_KEYCHAIN_PASSWORD }}
+
       - name: Upload iOS release bundle
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/create-prerelease.yml
+++ b/.github/workflows/create-prerelease.yml
@@ -5,6 +5,7 @@ env:
   VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
   VITE_GH_USER_FEEDBACK_PAT: ${{ secrets.GH_USER_FEEDBACK_PAT }}
+  FASTLANE_USER: ${{ secrets.FASTLANE_USER }}
 jobs:
   create-prerelease:
     permissions:
@@ -99,6 +100,7 @@ jobs:
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           APP_STORE_CONNECT_TEAM_ID: ${{ secrets.APP_STORE_CONNECT_TEAM_ID }}
           DEVELOPER_PORTAL_TEAM_ID: ${{ secrets.DEVELOPER_PORTAL_TEAM_ID }}
+          MATCH_KEYCHAIN_PASSWORD: ${{ secrets.MATCH_KEYCHAIN_PASSWORD }}
 
   deploy-android-beta:
     runs-on: macos-latest

--- a/.github/workflows/deploy-beta-ios.yml
+++ b/.github/workflows/deploy-beta-ios.yml
@@ -1,0 +1,70 @@
+name: Deploy iOS beta app
+on: workflow_dispatch
+
+env:
+  VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
+  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+  VITE_GH_USER_FEEDBACK_PAT: ${{ secrets.GH_USER_FEEDBACK_PAT }}
+
+jobs:
+  deploy-ios-beta:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Create build
+        env:
+          NODE_OPTIONS: "--max_old_space_size=4096"
+        run: npm run build
+
+      - name: Sync with Capacitor
+        run: npx cap sync
+
+      - name: Set up Ruby env
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.3.0
+          bundler-cache: true
+
+      - name: Get latest changelog contents
+        id: get-changelog-contents
+        run: |
+          fastlane_changelogs_dir=fastlane/metadata/android/en-US/changelogs
+
+          # Get latest build file name by finding file name with highest number (or default.txt as backup)
+          latest_build_file_name=$(exec ls $fastlane_changelogs_dir | sed 's/\([0-9]\+\).*/\1/g' | sort -n | tail -1)
+          full_file_path=$fastlane_changelogs_dir/$latest_build_file_name
+          changelog_contents="$(cat $full_file_path)"
+
+          # Allows multiline string to be passed to next step
+          echo "changelogContents<<EOF"$'\n'"$changelog_contents"$'\n'EOF >> "$GITHUB_OUTPUT"
+
+      - name: Deploy iOS beta app on TestFlight
+        run: bundle exec fastlane ios upload_beta changelogContents:"${{ steps.get-changelog-contents.outputs.changelogContents }}"
+        env:
+          DEVELOPER_APP_IDENTIFIER: ${{ secrets.DEVELOPER_APP_IDENTIFIER }}
+          DEVELOPER_APP_ID: ${{ secrets.DEVELOPER_APP_ID }}
+          PROVISIONING_PROFILE_SPECIFIER: match AppStore ${{ secrets.DEVELOPER_APP_IDENTIFIER }}
+          APPLE_ISSUER_ID: ${{ secrets.APPLE_ISSUER_ID }}
+          APPLE_KEY_ID: ${{ secrets.APPLE_KEY_ID }}
+          APPLE_KEY_CONTENT: ${{ secrets.APPLE_KEY_CONTENT }}
+          CERTIFICATE_STORE_URL: https://github.com/${{ secrets.CERTIFICATE_STORE_REPO }}.git
+          GIT_USERNAME: ${{ secrets.GIT_USERNAME }}
+          GIT_TOKEN: ${{ secrets.GIT_TOKEN }}
+          FASTLANE_APPLE_ID: ${{ secrets.FASTLANE_APPLE_ID }}
+          FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: ${{ secrets.FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD }}
+          FASTLANE_USER: ${{ secrets.FASTLANE_USER }}
+          MATCH_USERNAME: ${{ secrets.FASTLANE_APPLE_ID }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          APP_STORE_CONNECT_TEAM_ID: ${{ secrets.APP_STORE_CONNECT_TEAM_ID }}
+          DEVELOPER_PORTAL_TEAM_ID: ${{ secrets.DEVELOPER_PORTAL_TEAM_ID }}
+          MATCH_KEYCHAIN_PASSWORD: ${{ secrets.MATCH_KEYCHAIN_PASSWORD }}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -102,15 +102,25 @@ platform :ios do
     )
   end
 
+  # TODO: remove "skip_submission: true", added for testing purposes
   lane :upload_beta do |options|
     skip_docs
     changelog_contents = options[:changelogContents]
     build_beta
+    api_key = app_store_connect_api_key(
+      key_id: "#{APPLE_KEY_ID}",
+      issuer_id: "#{APPLE_ISSUER_ID}",
+      key_content: "#{APPLE_KEY_CONTENT}",
+      duration: 1200,
+      in_house: false,
+    )
     upload_to_testflight(
+      api_key: api_key,
       beta_app_feedback_email: "salemlfenn@gmail.com",
       changelog: "#{changelog_contents}",
       username: "#{FASTLANE_APPLE_ID}",
       app_identifier: "#{DEVELOPER_APP_IDENTIFIER}",
+      skip_submission: true,
     )
   end
 end


### PR DESCRIPTION
- Separate workflow for deploying iOS created
- Authenticating using app store connect
- Missing env variables added to workflows that build or deploy iOS
- Temporary `skip_submission: true` added to `upload_to_testflight` to prevent disaster lol