### PR TITLE
Deploy iOS Workflow - Remove Username

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -118,7 +118,6 @@ platform :ios do
       api_key: api_key,
       beta_app_feedback_email: "salemlfenn@gmail.com",
       changelog: "#{changelog_contents}",
-      username: "#{FASTLANE_APPLE_ID}",
       app_identifier: "#{DEVELOPER_APP_IDENTIFIER}",
       skip_submission: true,
     )

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -102,7 +102,6 @@ platform :ios do
     )
   end
 
-  # TODO: remove "skip_submission: true", added for testing purposes
   lane :upload_beta do |options|
     skip_docs
     changelog_contents = options[:changelogContents]
@@ -119,7 +118,6 @@ platform :ios do
       beta_app_feedback_email: "salemlfenn@gmail.com",
       changelog: "#{changelog_contents}",
       app_identifier: "#{DEVELOPER_APP_IDENTIFIER}",
-      skip_submission: true,
     )
   end
 end


### PR DESCRIPTION
- Username argument removed, conflicts with passing of API key
- No longer using `skip_submission` argument, not necessary