### PR TITLE
Removing Prerelease from iOS Version 

### DIFF
--- a/.github/workflows/bump-app-version.yml
+++ b/.github/workflows/bump-app-version.yml
@@ -50,11 +50,17 @@ jobs:
           ruby-version: 3.3.0
           bundler-cache: true
 
+      - name: Make version name iOS compatible
+        id: get-ios-version-name
+        run: |
+          version_no_prerelease=$(echo "${{ github.event.inputs.versionName }}" | sed 's/\([0-9.]*\).*/\1/')
+          echo "versionNoPrerelease=$version_no_prerelease" >> $GITHUB_OUTPUT
+
       - name: Increment iOS build number
         run: bundle exec fastlane ios bump
 
       - name: Update version name for iOS
-        run: bundle exec fastlane ios set_version_number version:${{ inputs.versionName }}
+        run: bundle exec fastlane ios set_version_number version:${{ steps.get-ios-version-name.outputs.versionNoPrerelease }}
 
       - name: Generate changelog
         uses: mikepenz/release-changelog-builder-action@v4

--- a/.github/workflows/bump-app-version.yml
+++ b/.github/workflows/bump-app-version.yml
@@ -50,7 +50,7 @@ jobs:
           ruby-version: 3.3.0
           bundler-cache: true
 
-      - name: Make version name iOS compatible
+      - name: Make version name iOS-compatible
         id: get-ios-version-name
         run: |
           version_no_prerelease=$(echo "${{ github.event.inputs.versionName }}" | sed 's/\([0-9.]*\).*/\1/')

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.0-beta</string>
+	<string>2.0.0</string>
 	<key>CFBundleVersion</key>
 	<string>3</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
- Accounting for iOS version names not allowing prerelease endings ("beta", "alpha", etc.)
- Manually updated version in Info.plist file to meet requirements