### PR TITLE
Truncate Changelog, Link to Full Release Notes

### DIFF
--- a/.github/config/changelog-config.json
+++ b/.github/config/changelog-config.json
@@ -1,6 +1,6 @@
 {
   "ignore_labels": ["ignore in changelog", "bump version"],
-  "template": "Changelog\n\n#{{CHANGELOG}}",
+  "template": "#{{CHANGELOG}}",
   "pr_template": "- #{{TITLE}}\n\t- Author: #{{AUTHOR}}",
   "categories": [
     {

--- a/.github/workflows/bump-app-version.yml
+++ b/.github/workflows/bump-app-version.yml
@@ -5,6 +5,8 @@ on:
       versionName:
         description: "Updated app version name"
         required: true
+env:
+  REPO_LOCATION: https://github.com/salemlf/hakubun
 
 jobs:
   bump-version-and-open-pr:
@@ -70,6 +72,22 @@ jobs:
           toTag: "HEAD"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Truncate changelog if more than 480 characters, add link to full release notes
+        run: |
+          ellipsis="..."
+          full_changelog_msg="\nFull changes available at ${{ env.REPO_LOCATION }}/releases/tag/v${{ inputs.versionName }}\n"
+          num_chars_to_truncate_to=$((480 - ${#ellipsis} -${#full_changelog_msg}))
+
+          changelog_file="fastlane/metadata/android/en-US/changelogs/${{ steps.get-android-build-number.outputs.versionCodeAndroid }}.txt"
+          changelog_length=$(cat "$changelog_file" | wc -m)
+
+          if [ $(cat "$changelog_file" | wc -m) -gt $(($num_chars_to_truncate_to)) ]; then
+            truncate -s $(($num_chars_to_truncate_to)) $changelog_file
+            echo -e "$ellipsis" >> $changelog_file
+          fi
+
+          echo -e "$full_changelog_msg" >> $changelog_file
 
       - name: Open pull request
         uses: peter-evans/create-pull-request@v5

--- a/fastlane/metadata/android/en-US/changelogs/50.txt
+++ b/fastlane/metadata/android/en-US/changelogs/50.txt
@@ -1,5 +1,3 @@
-Changelog
-
 Features/Enhancements
 
 - Adds sort by date updated
@@ -16,7 +14,6 @@ Bug Fixes
 
 Styling
 
-- Prevent Alt Meaning Modal Close on Outside Click, Increase "Add" Button Size
-	- Author: salemlf
-- Button Color Contrast Improvements
-	- Author: salemlf
+- Prevent Alt Meaning Modal Close on Outsid...
+
+Full changes available at https://github.com/salemlf/hakubun/releases/tag/v2.0.0-beta


### PR DESCRIPTION
- If generated changelog is over 480 characters, file content is truncated
- Link to full release note info added
- Manually edited old changelog to meet requirements