### PR TITLE
Mismatching Radical Image in Reviews and Lessons

### DIFF
--- a/src/components/AssignmentQueueCards/AssignmentCharAndType.tsx
+++ b/src/components/AssignmentQueueCards/AssignmentCharAndType.tsx
@@ -107,19 +107,19 @@ function AssignmentCharAndType({
 }: Props) {
   const { displayPopoverMsg, popoverInfo } = useQueueStoreFacade();
 
-  let popoverStyles = getPopoverStyles(popoverInfo.messageType);
+  const popoverStyles = getPopoverStyles(popoverInfo.messageType);
 
-  let subjType = currentReviewItem.object as SubjectType;
-  let reviewType = currentReviewItem.review_type;
-  let reviewTypeCapitalized = capitalizeWord(reviewType);
-  let reviewDisplayTxt = getSubjectTypeDisplayText(
+  const subjType = currentReviewItem.object as SubjectType;
+  const reviewType = currentReviewItem.review_type;
+  const reviewTypeCapitalized = capitalizeWord(reviewType);
+  const reviewDisplayTxt = getSubjectTypeDisplayText(
     currentReviewItem.object,
     false
   );
 
   // TODO: Not an ideal fix, so do padding/margin bottom and input focus fix later
   // Decreasing font size for vocab to avoid keyboard hidding input
-  let charFontSize =
+  const charFontSize =
     subjType === "vocabulary" || subjType === "kana_vocabulary"
       ? "3rem"
       : "4rem";

--- a/src/components/ImageFallback/ImageFallback.tsx
+++ b/src/components/ImageFallback/ImageFallback.tsx
@@ -33,7 +33,7 @@ function ImageFallback({ images, altText, ...props }: Props) {
     if (images && images.length > 0) {
       setCurrImg(images[0]);
     }
-  }, []);
+  }, [images]);
 
   return (
     <>

--- a/src/components/ImageFallback/ImageFallback.tsx
+++ b/src/components/ImageFallback/ImageFallback.tsx
@@ -14,7 +14,7 @@ const ImgWithAltText = styled.img`
 
 function ImageFallback({ images, altText, ...props }: Props) {
   const [currImg, setCurrImg] = useState<string>();
-  let defaultImagesAvail = images ? images : [];
+  const defaultImagesAvail = images ? images : [];
   const [imagesAvail, setImagesAvail] = useState<string[]>(defaultImagesAvail);
 
   const useImageFallback = (event: SyntheticEvent<HTMLImageElement, Event>) => {
@@ -23,7 +23,7 @@ function ImageFallback({ images, altText, ...props }: Props) {
       return;
     }
 
-    let updatedImagesAvail = imagesAvail.slice(1);
+    const updatedImagesAvail = imagesAvail.slice(1);
     setImagesAvail(updatedImagesAvail);
 
     event.currentTarget.src = updatedImagesAvail[0];

--- a/src/components/SubjectChars/SubjectChars.tsx
+++ b/src/components/SubjectChars/SubjectChars.tsx
@@ -82,7 +82,7 @@ function SubjectChars({
   withBgColor = false,
   disableTextSelection = false,
 }: Props) {
-  let subjType = subject.object as SubjectType;
+  const subjType = subject.object as SubjectType;
 
   return (
     <>


### PR DESCRIPTION
When more than one radical that uses an image was selected during a review session or lesson quiz, the incorrect radical ending up being displayed. This only happened once the first radical in the queue was shown, and after that it would continue to display the image of that first radical in the queue.

- Fixed by including images array as a dependency in `ImageFallback` component so current image updates as images array changes
- Changed some instances of `let` to `const`