### PR TITLE
Release Notes Improvements

### DIFF
--- a/.github/config/app-release-config.json
+++ b/.github/config/app-release-config.json
@@ -1,0 +1,35 @@
+{
+  "ignore_labels": ["ignore in changelog", "bump version"],
+  "template": "#{{CHANGELOG}}\n\n<details>\n<summary>❓ Uncategorized</summary>\n\n#{{UNCATEGORIZED}}\n</details>",
+  "pr_template": "- #{{TITLE}}\n\t- PR: ##{{NUMBER}}\n\t- Author: #{{AUTHOR}}",
+  "categories": [
+    {
+      "title": "## 🚀 Features/Enhancements",
+      "labels": ["enhancement"]
+    },
+    {
+      "title": "## 🐛 Bug Fixes",
+      "labels": ["bug"]
+    },
+    {
+      "title": "## 🧪 Tests",
+      "labels": ["tests"]
+    },
+    {
+      "title": "## 📦 Dependencies",
+      "labels": ["dependencies"]
+    },
+    {
+      "title": "## 📝 Documentation",
+      "labels": ["documentation"]
+    },
+    {
+      "title": "## 🔧 CICD",
+      "labels": ["cicd"]
+    },
+    {
+      "title": "## ✨ Styling",
+      "labels": ["styling"]
+    }
+  ]
+}

--- a/.github/workflows/create-prerelease.yml
+++ b/.github/workflows/create-prerelease.yml
@@ -20,6 +20,7 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Get current version
         id: getAppVersion
         run: |

--- a/.github/workflows/create-prerelease.yml
+++ b/.github/workflows/create-prerelease.yml
@@ -34,12 +34,21 @@ jobs:
           git tag -a "$updated_tag" -m "Version $updated_tag"
           git push origin --tags
 
+      - name: Generate release notes
+        id: generate-release-notes
+        uses: mikepenz/release-changelog-builder-action@v4
+        with:
+          configuration: ".github/config/app-release-config.json"
+          toTag: "HEAD"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.getAppVersion.outputs.version }}
         run: |
-          gh release create "$tag" --generate-notes --prerelease
+          gh release create "$tag" --notes ${{steps.generate-release-notes.outputs.changelog}} --prerelease
 
   deploy-ios-beta:
     runs-on: macos-latest


### PR DESCRIPTION
Using [release-changelog-builder-action](https://github.com/mikepenz/release-changelog-builder-action) to create release notes instead of default generated by GitHub