### PR TITLE
Indicating Primary Kanji Reading(s)

### DIFF
--- a/src/components/HelpSpan/HelpSpan.tsx
+++ b/src/components/HelpSpan/HelpSpan.tsx
@@ -33,12 +33,16 @@ const Punctuation = styled.span<PunctuationProps>`
 
 type ClickableHelpProps = {
   $isBold: boolean;
+  $hidePunctuation: boolean;
 };
 
 const ClickableHelp = styled.button<ClickableHelpProps>`
   all: unset;
   color: var(--text-color);
   font-weight: ${({ $isBold }) => ($isBold ? "600" : "400")};
+
+  display: ${({ $hidePunctuation }) => $hidePunctuation && "flex"};
+  align-items: ${({ $hidePunctuation }) => $hidePunctuation && "center"};
 
   &:focus-visible {
     outline: 2px solid var(--focus-color);
@@ -78,6 +82,7 @@ const punctuationMap: Record<PunctuationType, PunctuationContent> = {
 type Props = {
   children: React.ReactNode;
   helpPopoverContents: React.ReactNode;
+  hidePunctuation?: boolean;
   punctuation?: PunctuationType;
   isBold?: boolean;
 };
@@ -85,6 +90,7 @@ type Props = {
 function HelpSpan({
   children,
   helpPopoverContents,
+  hidePunctuation = false,
   punctuation = "question",
   isBold = false,
 }: Props) {
@@ -95,11 +101,13 @@ function HelpSpan({
     <ContainerSpan>
       <PopoverRoot open={isOpen} onOpenChange={setIsOpen}>
         <PopoverTrigger asChild>
-          <ClickableHelp $isBold={isBold}>
+          <ClickableHelp $isBold={isBold} $hidePunctuation={hidePunctuation}>
             {children}
-            <Punctuation $color={punctuationInfo.color}>
-              {punctuationInfo.text}
-            </Punctuation>
+            {!hidePunctuation && (
+              <Punctuation $color={punctuationInfo.color}>
+                {punctuationInfo.text}
+              </Punctuation>
+            )}
           </ClickableHelp>
         </PopoverTrigger>
         <Popover isOpen={isOpen} showBorder={true}>

--- a/src/components/ReadingsForKanji/ReadingsForKanji.tsx
+++ b/src/components/ReadingsForKanji/ReadingsForKanji.tsx
@@ -18,7 +18,6 @@ type Props = {
   hideReadingType?: boolean;
 };
 
-// TODO: sort readings with primary first
 function ReadingsForKanji({
   kanji,
   readingType,

--- a/src/components/ReadingsForKanji/ReadingsForKanji.tsx
+++ b/src/components/ReadingsForKanji/ReadingsForKanji.tsx
@@ -1,9 +1,9 @@
 import { getKanjiReadings } from "../../services/SubjectAndAssignmentService/SubjectAndAssignmentService";
-import { Kanji } from "../../types/Subject";
+import { Kanji, ReadingType } from "../../types/Subject";
 import { ReadingsStyle } from "../../styles/SubjectDetailsStyled";
 import styled from "styled-components";
 
-const ReadingType = styled.h5`
+const ReadingTypeHeading = styled.h5`
   font-size: 1rem;
   margin: 10px 0 5px 0;
 `;
@@ -14,7 +14,7 @@ const KanjiReadings = styled(ReadingsStyle)`
 
 type Props = {
   kanji: Kanji;
-  readingType: "onyomi" | "kunyomi";
+  readingType: ReadingType;
   hideReadingType?: boolean;
 };
 
@@ -29,7 +29,9 @@ function ReadingsForKanji({
 
   return (
     <>
-      {!hideReadingType && <ReadingType>{readingDisplayName}</ReadingType>}
+      {!hideReadingType && (
+        <ReadingTypeHeading>{readingDisplayName}</ReadingTypeHeading>
+      )}
       <KanjiReadings>
         {kanjiReadings && kanjiReadings.length
           ? kanjiReadings

--- a/src/components/ReadingsForKanji/ReadingsForKanji.tsx
+++ b/src/components/ReadingsForKanji/ReadingsForKanji.tsx
@@ -1,5 +1,7 @@
 import { getKanjiReadings } from "../../services/SubjectAndAssignmentService/SubjectAndAssignmentService";
+import SvgIcon from "../SvgIcon";
 import { Kanji, ReadingType } from "../../types/Subject";
+import CheckCircleIcon from "../../images/check-in-circle.svg?react";
 import { ReadingsStyle } from "../../styles/SubjectDetailsStyled";
 import styled from "styled-components";
 
@@ -14,6 +16,7 @@ const KanjiReadings = styled(ReadingsStyle)`
 
 const ReadingContainer = styled.div`
   display: flex;
+  align-items: center;
 `;
 
 const readingTypeDisplayNameMap: Record<ReadingType, string> = {
@@ -46,6 +49,13 @@ function ReadingsForKanji({
           ? kanjiReadings.map((kanjiReading, index) => [
               <ReadingContainer key={`${kanjiReading.reading}_${index}`}>
                 {kanjiReading.reading}
+                {kanjiReading.primary && (
+                  <SvgIcon
+                    icon={<CheckCircleIcon />}
+                    width="1em"
+                    height="1em"
+                  />
+                )}
                 {index >= 0 && index !== kanjiReadings.length - 1 && ","}
               </ReadingContainer>,
             ])

--- a/src/components/ReadingsForKanji/ReadingsForKanji.tsx
+++ b/src/components/ReadingsForKanji/ReadingsForKanji.tsx
@@ -12,6 +12,10 @@ const KanjiReadings = styled(ReadingsStyle)`
   flex-wrap: wrap;
 `;
 
+const ReadingContainer = styled.div`
+  display: flex;
+`;
+
 const readingTypeDisplayNameMap: Record<ReadingType, string> = {
   onyomi: "On'yomi",
   kunyomi: "Kun'yomi",
@@ -39,11 +43,12 @@ function ReadingsForKanji({
       )}
       <KanjiReadings>
         {kanjiReadings && kanjiReadings.length
-          ? kanjiReadings
-              .map((kanjiReading) => {
-                return kanjiReading.reading;
-              })
-              .join(", ")
+          ? kanjiReadings.map((kanjiReading, index) => [
+              <ReadingContainer key={`${kanjiReading.reading}_${index}`}>
+                {kanjiReading.reading}
+                {index >= 0 && index !== kanjiReadings.length - 1 && ","}
+              </ReadingContainer>,
+            ])
           : "-"}
       </KanjiReadings>
     </>

--- a/src/components/ReadingsForKanji/ReadingsForKanji.tsx
+++ b/src/components/ReadingsForKanji/ReadingsForKanji.tsx
@@ -12,6 +12,12 @@ const KanjiReadings = styled(ReadingsStyle)`
   flex-wrap: wrap;
 `;
 
+const readingTypeDisplayNameMap: Record<ReadingType, string> = {
+  onyomi: "On'yomi",
+  kunyomi: "Kun'yomi",
+  nanori: "Nanori",
+};
+
 type Props = {
   kanji: Kanji;
   readingType: ReadingType;
@@ -24,13 +30,12 @@ function ReadingsForKanji({
   hideReadingType = false,
 }: Props) {
   const kanjiReadings = getKanjiReadings(kanji.readings, readingType);
-  const readingDisplayName =
-    readingType === "onyomi" ? "On'yomi Readings" : "Kun'yomi Readings";
+  const readingTypeDisplayName = `${readingTypeDisplayNameMap[readingType]} Readings`;
 
   return (
     <>
       {!hideReadingType && (
-        <ReadingTypeHeading>{readingDisplayName}</ReadingTypeHeading>
+        <ReadingTypeHeading>{readingTypeDisplayName}</ReadingTypeHeading>
       )}
       <KanjiReadings>
         {kanjiReadings && kanjiReadings.length

--- a/src/components/ReadingsForKanji/ReadingsForKanji.tsx
+++ b/src/components/ReadingsForKanji/ReadingsForKanji.tsx
@@ -24,8 +24,8 @@ function ReadingsForKanji({
   readingType,
   hideReadingType = false,
 }: Props) {
-  let kanjiReadings = getKanjiReadings(kanji.readings, readingType);
-  let readingDisplayName =
+  const kanjiReadings = getKanjiReadings(kanji.readings, readingType);
+  const readingDisplayName =
     readingType === "onyomi" ? "On'yomi Readings" : "Kun'yomi Readings";
 
   return (
@@ -34,7 +34,7 @@ function ReadingsForKanji({
       <KanjiReadings>
         {kanjiReadings && kanjiReadings.length
           ? kanjiReadings
-              .map((kanjiReading: any) => {
+              .map((kanjiReading) => {
                 return kanjiReading.reading;
               })
               .join(", ")

--- a/src/components/ReadingsForKanji/ReadingsForKanji.tsx
+++ b/src/components/ReadingsForKanji/ReadingsForKanji.tsx
@@ -1,6 +1,7 @@
 import { getKanjiReadings } from "../../services/SubjectAndAssignmentService/SubjectAndAssignmentService";
 import SvgIcon from "../SvgIcon";
-import { Kanji, ReadingType } from "../../types/Subject";
+import HelpSpan from "../HelpSpan";
+import { Kanji, ReadingType, SubjectReading } from "../../types/Subject";
 import CheckCircleIcon from "../../images/check-in-circle.svg?react";
 import { ReadingsStyle } from "../../styles/SubjectDetailsStyled";
 import styled from "styled-components";
@@ -17,6 +18,10 @@ const KanjiReadings = styled(ReadingsStyle)`
 const ReadingContainer = styled.div`
   display: flex;
   align-items: center;
+
+  p {
+    margin: 0;
+  }
 `;
 
 const readingTypeDisplayNameMap: Record<ReadingType, string> = {
@@ -48,14 +53,16 @@ function ReadingsForKanji({
         {kanjiReadings && kanjiReadings.length
           ? kanjiReadings.map((kanjiReading, index) => [
               <ReadingContainer key={`${kanjiReading.reading}_${index}`}>
-                {kanjiReading.reading}
-                {kanjiReading.primary && (
-                  <SvgIcon
-                    icon={<CheckCircleIcon />}
-                    width="1em"
-                    height="1em"
-                  />
-                )}
+                <KanjiReading reading={kanjiReading}>
+                  <p>{kanjiReading.reading}</p>
+                  {kanjiReading.primary && (
+                    <SvgIcon
+                      icon={<CheckCircleIcon />}
+                      width="1em"
+                      height="1em"
+                    />
+                  )}
+                </KanjiReading>
                 {index >= 0 && index !== kanjiReadings.length - 1 && ","}
               </ReadingContainer>,
             ])
@@ -64,5 +71,40 @@ function ReadingsForKanji({
     </>
   );
 }
+
+const PrimaryReadingHelp = styled.div`
+  font-size: 0.875rem;
+  color: var(--text-color);
+  p {
+    margin: 0;
+  }
+`;
+
+const PrimaryReadingHelpContents = (
+  <PrimaryReadingHelp>
+    <p>
+      This is a primary reading for the kanji; it's one of the most likely
+      readings to be used when the kanji is present in vocabulary.
+    </p>
+  </PrimaryReadingHelp>
+);
+
+type KanjiReadingProps = {
+  reading: SubjectReading;
+  children: React.ReactNode;
+};
+
+const KanjiReading = ({ reading, children }: KanjiReadingProps) => {
+  return reading.primary ? (
+    <HelpSpan
+      helpPopoverContents={PrimaryReadingHelpContents}
+      hidePunctuation={true}
+    >
+      {children}
+    </HelpSpan>
+  ) : (
+    children
+  );
+};
 
 export default ReadingsForKanji;


### PR DESCRIPTION
## Kanji Readings
- Primary reading(s) for kanji are shown with a checkmark icon next to them
- Primary readings are also underlined with a help popup that appears on click, explains meaning of checkmark icon and primary reading
- Using `ReadingType` as property type to account for when nanori readings could also be possible
- Minor refactor for displaying commas between readings
## Help Span
- Allowing option for no punctuation to be shown 