### PR TITLE
Release Notes Generation Fix for Create Prerelease Workflow

### DIFF
--- a/.github/workflows/create-prerelease.yml
+++ b/.github/workflows/create-prerelease.yml
@@ -21,16 +21,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set git info
+        run: |
+          git config --global user.email "salemlfenn@gmail.com"
+          git config --global user.name "Salem Fenn"
+
+      - name: Get previous tag
+        id: get_prev_tag
+        run: |
+          echo "prevTag=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
+
       - name: Get current version
         id: getAppVersion
         run: |
           echo "version=v$(cat package.json | grep \"version\" | cut -d'"' -f 4)" >> $GITHUB_OUTPUT
 
-      - name: Set git info and tag the commit
+      - name: Create new tag
         run: |
-          git config --global user.email "salemlfenn@gmail.com"
-          git config --global user.name "Salem Fenn"
-
           updated_tag=${{ steps.getAppVersion.outputs.version }}
           git tag -a "$updated_tag" -m "Version $updated_tag"
           git push origin --tags
@@ -40,6 +47,7 @@ jobs:
         uses: mikepenz/release-changelog-builder-action@v4
         with:
           configuration: ".github/config/app-release-config.json"
+          fromTag: "${{ steps.get_prev_tag.outputs.prevTag }}"
           toTag: "HEAD"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -49,7 +57,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.getAppVersion.outputs.version }}
         run: |
-          gh release create "$tag" --notes ${{steps.generate-release-notes.outputs.changelog}} --prerelease
+          gh release create "$tag" --notes "${{steps.generate-release-notes.outputs.changelog}}" --prerelease
 
   deploy-ios-beta:
     runs-on: macos-latest

--- a/.github/workflows/create-prerelease.yml
+++ b/.github/workflows/create-prerelease.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           configuration: ".github/config/app-release-config.json"
           fromTag: "${{ steps.get_prev_tag.outputs.prevTag }}"
-          toTag: "HEAD"
+          toTag: "${{ steps.getAppVersion.outputs.version }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/create-prerelease.yml
+++ b/.github/workflows/create-prerelease.yml
@@ -60,6 +60,7 @@ jobs:
           gh release create "$tag" --notes "${{steps.generate-release-notes.outputs.changelog}}" --prerelease
 
   deploy-ios-beta:
+    needs: create-prerelease
     runs-on: macos-latest
     steps:
       - name: Checkout
@@ -121,6 +122,7 @@ jobs:
           MATCH_KEYCHAIN_PASSWORD: ${{ secrets.MATCH_KEYCHAIN_PASSWORD }}
 
   deploy-android-beta:
+    needs: create-prerelease
     runs-on: macos-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
- Uses correct tags to compare changes
- Creating prerelease is required before running deploy for iOS or Android beta apps 