### PR TITLE
Background Color for Show/Hide Context Sentence Translation Button

### DIFF
--- a/src/components/ContextSentences/ContextSentences.tsx
+++ b/src/components/ContextSentences/ContextSentences.tsx
@@ -95,6 +95,7 @@ function ContextSentences({ sentences }: Props) {
                   <EyeBallButton
                     onPress={() => toggleTranslationBlur(index)}
                     aria-label={`Show/Hide English Translation for Context Sentence ${index}`}
+                    backgroundColor="var(--ion-color-primary)"
                   >
                     <SvgIcon
                       icon={


### PR DESCRIPTION
Color changed back to lighter purple