### PR TITLE
Automatically Deploy iOS Beta to External Testers

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -119,6 +119,8 @@ platform :ios do
       changelog: "#{changelog_contents}",
       app_identifier: "#{DEVELOPER_APP_IDENTIFIER}",
       submit_beta_review: true,
+      groups: ["hakubun_beta_testers_external"],
+      distribute_external: true,
     )
   end
 end


### PR DESCRIPTION
Beta app now deploys externally too without manual intervention