### PR TITLE
Retry Delay Configuration for Rate Limiting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,6 @@ import {
   useNavigationType,
 } from "react-router-dom";
 import { IonApp, setupIonicReact } from "@ionic/react";
-import { AxiosError } from "axios";
 import {
   QueryCache,
   QueryClient,

--- a/src/services/ApiQueryService/ApiQueryService.tsx
+++ b/src/services/ApiQueryService/ApiQueryService.tsx
@@ -41,3 +41,19 @@ export const onQueryError = (
     }
   }
 };
+
+export const getRetryDelay = (attemptIndex: number, error: Error) => {
+  // accounting for rate limiting, retrying after rate limit resets
+  if (
+    error &&
+    error instanceof AxiosError &&
+    error.response?.status === 429 &&
+    error.response.headers["ratelimit-reset"]
+  ) {
+    const rateLimitResetTime = error.response.headers["ratelimit-reset"];
+    const rateLimitResetTimeMs = parseInt(rateLimitResetTime) * 1000;
+    const timeToReset = rateLimitResetTimeMs - Date.now() + 1000;
+    return timeToReset;
+  }
+  return Math.min(1000 * 2 ** attemptIndex, 30000);
+};


### PR DESCRIPTION
When "429 Too many requests" error occurs, retry delay is based on `ratelimit-reset` header returned. This prevents eternal loading for pages that make a large number of requests
- Configured for both queries and mutations