### PR TITLE
Content Cut Off at Bottom of Subject Info Tab Content

### DIFF
--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -17,6 +17,8 @@ const TabsStyled = styled(TabsPrimitive.Root)`
   max-width: 100%;
   height: 100%;
   margin: auto;
+  display: flex;
+  flex-direction: column;
 `;
 
 const TabPanels = styled.div`
@@ -24,6 +26,7 @@ const TabPanels = styled.div`
   display: flex;
   overflow-x: auto;
   margin: 0;
+  margin-bottom: 20px;
   font-size: 0.875rem;
   line-height: 1.25rem;
   font-weight: 300;


### PR DESCRIPTION
Using flexbox and bottom margin to prevent content from being cut off in tabs when tab content becomes scrollable 