### PR TITLE
Delaying Modal Animations to Account for Keyboard

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -8,9 +8,9 @@ import { Content, Overlay } from "./Modal.styles";
 import styled from "styled-components";
 
 type Props = {
-  children: React.ReactNode;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
+  children: React.ReactNode;
 };
 
 function Modal({ open, onOpenChange, children }: Props) {
@@ -54,7 +54,8 @@ const IconAndTitleContainer = styled.div`
   word-break: break-word;
 `;
 
-const DELAY = 0.3;
+const OVERLAY_DELAY = 0.3;
+const CONTENT_DELAY = 0.5;
 type ContentRef = HTMLDivElement;
 
 type ContentProps = {
@@ -63,6 +64,7 @@ type ContentProps = {
   description?: string;
   children: React.ReactNode;
   isOpen: boolean;
+  delayOpenClose?: boolean;
   icon?: React.ReactNode;
   closeOnOutsidePress?: boolean;
 };
@@ -77,6 +79,7 @@ export const ModalContent = forwardRef<ContentRef, ContentProps>(
       isOpen,
       icon,
       closeOnOutsidePress = true,
+      delayOpenClose = false,
       ...props
     },
     forwardedRef
@@ -95,8 +98,18 @@ export const ModalContent = forwardRef<ContentRef, ContentProps>(
                 <DialogPrimitive.Overlay asChild>
                   <Overlay
                     initial={{ opacity: 0 }}
-                    animate={{ opacity: 1, transition: { delay: DELAY } }}
-                    exit={{ opacity: 0 }}
+                    animate={{
+                      opacity: 1,
+                      transition: {
+                        delay: delayOpenClose ? CONTENT_DELAY : OVERLAY_DELAY,
+                      },
+                    }}
+                    exit={{
+                      opacity: 0,
+                      transition: {
+                        delay: delayOpenClose ? CONTENT_DELAY : OVERLAY_DELAY,
+                      },
+                    }}
                   />
                 </DialogPrimitive.Overlay>
                 <DialogPrimitive.Content
@@ -113,8 +126,15 @@ export const ModalContent = forwardRef<ContentRef, ContentProps>(
                 >
                   <Content
                     initial={{ scale: 0 }}
-                    animate={{ scale: 1 }}
-                    exit={{ scale: 0 }}
+                    // animate={{ scale: 1 }}
+                    animate={{
+                      scale: 1,
+                      transition: { delay: delayOpenClose ? CONTENT_DELAY : 0 },
+                    }}
+                    exit={{
+                      scale: 0,
+                      transition: { delay: delayOpenClose ? CONTENT_DELAY : 0 },
+                    }}
                   >
                     <TitleBar>
                       <IconAndTitleContainer>

--- a/src/components/SubjectMeanings/AddAltUserMeaningButton.tsx
+++ b/src/components/SubjectMeanings/AddAltUserMeaningButton.tsx
@@ -118,6 +118,7 @@ function AddAltUserMeaningButton({ subject }: Props) {
               modalID="add-alt-user-meaning-modal"
               title="Add Meaning"
               isOpen={isModalOpen}
+              delayOpenClose={true}
               description="Add an alternative meaning, this will be accepted as a correct answer!"
               closeOnOutsidePress={false}
             >

--- a/src/components/UserFeedbackModal/ErrReportModal.tsx
+++ b/src/components/UserFeedbackModal/ErrReportModal.tsx
@@ -80,8 +80,8 @@ function ErrReportModal({ isOpen, setIsOpen, errMsg, stackTrace }: Props) {
   }, [isOpen]);
 
   useEffect(() => {
-    if (isOpen && textareaRef.current) {
-      textareaRef.current.focus();
+    if (textareaRef.current) {
+      isOpen ? textareaRef.current.focus() : textareaRef.current.blur();
     }
   }, [isOpen]);
 
@@ -109,6 +109,7 @@ function ErrReportModal({ isOpen, setIsOpen, errMsg, stackTrace }: Props) {
           modalID="err-report-modal"
           title="Send Error Report"
           isOpen={isOpen}
+          delayOpenClose={true}
           description="The error report will be sent to the developer. It'll include the error message, stack trace, and any additional info you provide."
         >
           <form onSubmit={submitErrReport}>

--- a/src/components/UserFeedbackModal/UserFeedbackModal.tsx
+++ b/src/components/UserFeedbackModal/UserFeedbackModal.tsx
@@ -225,8 +225,10 @@ function UserFeedbackModal({ isOpen, setIsOpen }: Props) {
   }, [isOpen, setIsReportSubmitting]);
 
   useEffect(() => {
-    if (isOpen && feedbackTypeSelectorRef.current) {
-      feedbackTypeSelectorRef.current.focus();
+    if (feedbackTypeSelectorRef.current) {
+      isOpen
+        ? feedbackTypeSelectorRef.current.focus()
+        : feedbackTypeSelectorRef.current.blur();
     }
   }, [isOpen]);
 
@@ -260,6 +262,7 @@ function UserFeedbackModal({ isOpen, setIsOpen }: Props) {
         modalID="user-feedback-modal"
         title="Send User Feedback"
         isOpen={isOpen}
+        delayOpenClose={true}
         description="This info will be sent to the developer. You can ask a question, suggest a feature, or report a bug!"
       >
         <form noValidate onSubmit={handleSubmit(submitFeedback)}>

--- a/src/components/UserNote/EditNoteModal.tsx
+++ b/src/components/UserNote/EditNoteModal.tsx
@@ -114,10 +114,15 @@ function EditNoteModal({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
-    if (isOpen && textareaRef.current) {
-      textareaRef.current.focus();
-      // cursor moved to end of text
-      textareaRef.current.selectionStart = textareaRef.current.value.length;
+    if (textareaRef.current) {
+      if (isOpen) {
+        textareaRef.current.focus();
+        // cursor moved to end of text
+        textareaRef.current.selectionStart = textareaRef.current.value.length;
+      } else {
+        // helps prevent icky animation choppiness when closing modal
+        textareaRef.current.blur();
+      }
     }
   }, [isOpen]);
 
@@ -165,6 +170,7 @@ function EditNoteModal({
         modalID="add-user-note-modal"
         title={`${noteTypeCapitalized} Note`}
         isOpen={isOpen}
+        delayOpenClose={true}
         description={`Come up with a note that helps you remember the ${noteType}!`}
         icon={noteType === "meaning" ? <MeaningIcon /> : <ReadingIcon />}
         closeOnOutsidePress={false}


### PR DESCRIPTION
For modals where there's an immediate input focus, the animation to display the modal is now slightly delayed on open and close. This way it prevents the issue where the modal appears, then immediately moves up to accomodate for the keyboard