### PR TITLE
Partial Page Scroll Restoration Support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "sass": "^1.62.1",
         "styled-components": "^5.3.11",
         "type-fest": "^4.6.0",
+        "use-scroll-restoration": "^1.0.0",
         "usehooks-ts": "^3.0.2",
         "wanakana": "^5.1.0",
         "zustand": "^4.4.1"
@@ -10250,6 +10251,26 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
+    "node_modules/jotai": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.8.3.tgz",
+      "integrity": "sha512-pR4plVvdbzB6zyt7VLLHPMAkcRSKhRIvZKd+qkifQLa3CEziEo1uwZjePj4acTmQrboiISBlYSdCz3gWcr1Nkg==",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=17.0.0",
+        "react": ">=17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -14256,6 +14277,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-scroll-restoration": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/use-scroll-restoration/-/use-scroll-restoration-1.0.0.tgz",
+      "integrity": "sha512-ZpDsqjuftS6MPFH4WPOFaIWZk85ZotpDkbkDSyxVcAHZxW7MVkCWP7O7FlGO5icYNiPOzEUohnVtsy2Sh6Jr0A==",
+      "dependencies": {
+        "jotai": "^2.4.0",
+        "react": "^18.2.0"
       }
     },
     "node_modules/use-sidecar": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "sass": "^1.62.1",
     "styled-components": "^5.3.11",
     "type-fest": "^4.6.0",
+    "use-scroll-restoration": "^1.0.0",
     "usehooks-ts": "^3.0.2",
     "wanakana": "^5.1.0",
     "zustand": "^4.4.1"

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { IonSkeletonText } from "@ionic/react";
+import { useScrollRestoration } from "use-scroll-restoration";
 import useUserInfoStoreFacade from "../stores/useUserInfoStore/useUserInfoStore.facade";
 import { useAuthTokenStore } from "../stores/useAuthTokenStore/useAuthTokenStore";
 import { useUserInfo } from "../hooks/user/useUserInfo";
@@ -36,6 +37,11 @@ const Home = () => {
   const [level, setLevel] = useState<number | undefined>();
   const { setUserInfo, userInfo } = useUserInfoStoreFacade();
 
+  const { ref } = useScrollRestoration("homePageScroll", {
+    debounceTime: 200,
+    persist: "sessionStorage",
+  });
+
   useEffect(() => {
     setHomeLoading(true);
     setUserDetails();
@@ -66,7 +72,7 @@ const Home = () => {
   return (
     <HydrationWrapper store={useAuthTokenStore as PersistentStore}>
       <HomeHeader></HomeHeader>
-      <HomePageContainer>
+      <HomePageContainer ref={ref}>
         {!homeLoading ? (
           <>
             <LessonAndReviewButtonsContainer>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -30,8 +30,6 @@ const LessonAndReviewButtonsContainer = styled.div`
   margin-bottom: 16px;
 `;
 
-// TODO: modify so LevelProgressBar, RadicalsForLvlCard, and KanjiForLvlCard show loading skeletons if level is undefined
-// TODO: save previous level value and show animation/congrats when level increases
 const Home = () => {
   const [homeLoading, setHomeLoading] = useState(false);
   const [level, setLevel] = useState<number | undefined>();

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, ChangeEvent } from "react";
-import { IonList } from "@ionic/react";
 import Fuse from "fuse.js";
 import { AnimatePresence, motion } from "framer-motion";
 import { useDebounceValue } from "usehooks-ts";
+import { useScrollRestoration } from "use-scroll-restoration";
 import { flattenSearchResults } from "../services/MiscService/MiscService";
 import { useTabBarHeight } from "../contexts/TabBarHeightContext";
 import { useAllSubjects } from "../hooks/subjects/useAllSubjects";
@@ -18,15 +18,10 @@ import LogoExclamation from "../images/logo-exclamation.svg";
 import { ContentWithTabBar } from "../styles/BaseStyledComponents";
 import styled from "styled-components";
 
-type ContentProps = {
-  $tabBarHeight: string;
-};
-
-const Content = styled(ContentWithTabBar)<ContentProps>`
-  padding: 12px;
+const Content = styled(ContentWithTabBar)`
+  padding: 12px 10px;
   display: grid;
   grid-template-rows: auto 1fr;
-  padding-bottom: ${({ $tabBarHeight }) => `calc(${$tabBarHeight} + 20px)`};
   height: 100dvh;
 `;
 
@@ -42,6 +37,7 @@ const ClearButton = styled(Button)`
 `;
 
 const Form = styled.form`
+  margin: 0 5px;
   display: flex;
 
   &:focus-within,
@@ -70,12 +66,16 @@ const SearchBar = styled.input`
   border: none;
 `;
 
-// TODO: change from IonList
-const List = styled(IonList)`
-  --background: none;
-  background: none;
+type ListProps = {
+  $tabBarHeight: string;
+};
+
+const List = styled.ul<ListProps>`
+  max-height: 100dvh;
+  overflow-y: auto;
   margin: 0;
-  padding: 8px 0;
+  padding: 8px 5px;
+  padding-bottom: ${({ $tabBarHeight }) => `calc(${$tabBarHeight} + 20px)`};
 `;
 
 const LogoSearchOutcomeContainer = styled.div`
@@ -96,6 +96,10 @@ const crabigatorVariants = {
 };
 
 export const Search = () => {
+  const { ref } = useScrollRestoration("searchPageListScroll", {
+    debounceTime: 100,
+    persist: "localStorage",
+  });
   const [results, setResults] = useState<Fuse.FuseResult<unknown>[]>([]);
   const [query, setQuery] = useStickyState("", "search-page-query");
   const [debouncedQuery] = useDebounceValue(query, 1800);
@@ -144,7 +148,6 @@ export const Search = () => {
 
   return (
     <Content
-      $tabBarHeight={tabBarHeight}
       as={motion.main}
       style={
         showPlaceholder ? { alignItems: "center" } : { alignItems: "stretch" }
@@ -212,6 +215,8 @@ export const Search = () => {
               </LogoSearchOutcomeContainer>
             ) : (
               <List
+                ref={ref}
+                $tabBarHeight={tabBarHeight}
                 key="results-found"
                 as={motion.div}
                 layoutScroll

--- a/src/pages/SubjectDetails.tsx
+++ b/src/pages/SubjectDetails.tsx
@@ -1,6 +1,7 @@
 import { useNavigate, useParams } from "react-router-dom";
 import { IonSkeletonText } from "@ionic/react";
 import { AnimatePresence } from "framer-motion";
+import { useScrollRestoration } from "use-scroll-restoration";
 import useAssignmentQueueStoreFacade from "../stores/useAssignmentQueueStore/useAssignmentQueueStore.facade";
 import { capitalizeWord } from "../services/MiscService/MiscService";
 import { useSubjectByID } from "../hooks/subjects/useSubjectByID";
@@ -66,6 +67,11 @@ export const SubjectDetails = () => {
   const { id } = useParams<{ id?: string }>();
   const parsedID = parseInt(id!);
 
+  const { ref } = useScrollRestoration(`subjectDetailsPageScroll${id}`, {
+    debounceTime: 200,
+    persist: "localStorage",
+  });
+
   const { sessionInProgress: isSessionInProgress, sessionType } =
     useAssignmentQueueStoreFacade();
 
@@ -98,7 +104,7 @@ export const SubjectDetails = () => {
       {subjectData && (
         <>
           <SubjectHeader subject={subjectData} />
-          <ContentWithTabBar data-testid="subject-details-page">
+          <ContentWithTabBar data-testid="subject-details-page" ref={ref}>
             <FullWidthGrid>
               <SubjectSummary subject={subjectData}></SubjectSummary>
               {subjectData.object == "radical" && (

--- a/src/pages/Subjects.tsx
+++ b/src/pages/Subjects.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState, useRef } from "react";
 import { motion } from "framer-motion";
+import { useScrollRestoration } from "use-scroll-restoration";
 import { LEVELS } from "../constants";
+import { mergeRefs } from "../utils";
 import useUserInfoStoreFacade from "../stores/useUserInfoStore/useUserInfoStore.facade";
 import { useTabBarHeight } from "../contexts/TabBarHeightContext";
 import { useStickyState } from "../hooks/useStickyState";
@@ -171,6 +173,11 @@ const SubjectTabs = ({
   setSelectedIndex,
 }: SubjectTabsProps) => {
   const tabListRef = useRef<HTMLDivElement | null>(null);
+  const { ref } = useScrollRestoration("subjectsTabsScroll", {
+    debounceTime: 200,
+    persist: "localStorage",
+  });
+
   const [tabElements, setTabElements] = useState<HTMLButtonElement[]>([]);
   useEffect(() => {
     if (tabElements.length === 0 && tabListRef.current) {
@@ -204,7 +211,7 @@ const SubjectTabs = ({
   }, [selectedIndex, tabListRef.current]);
 
   return (
-    <TabContainer ref={tabListRef}>
+    <TabContainer ref={mergeRefs(tabListRef, ref)}>
       {tabLabels.map((label) => {
         return (
           <PageTab

--- a/src/pages/Subjects.tsx
+++ b/src/pages/Subjects.tsx
@@ -10,17 +10,23 @@ import { getPageIndex } from "../services/MiscService/MiscService";
 import SubjectsOnLvlTab from "../components/SubjectsOnLvlTab/SubjectsOnLvlTab";
 import LoadingDots from "../components/LoadingDots";
 import Paginator from "../components/Paginator";
-import { FixedCenterContainer, Header } from "../styles/BaseStyledComponents";
+import {
+  ContentWithTabBar,
+  FixedCenterContainer,
+  Header,
+} from "../styles/BaseStyledComponents";
 import styled from "styled-components";
 
-type HeaderAndTabsContainerProps = {
+type SubjectsPageContainerProps = {
   $tabBarHeight: string;
 };
 
-const HeaderAndTabsContainer = styled.div<HeaderAndTabsContainerProps>`
-  display: grid;
-  grid-template-rows: auto 1fr;
-  height: 100%;
+const SubjectsPageContainer = styled(
+  ContentWithTabBar
+)<SubjectsPageContainerProps>`
+  overflow-y: auto;
+  min-height: 100dvh;
+  padding: 0;
   padding-bottom: ${({ $tabBarHeight }) => `calc(${$tabBarHeight} + 30px)`};
 `;
 
@@ -85,7 +91,7 @@ const SubjectsContent = ({ level, setLevel }: SubjectsContentProps) => {
   };
 
   return (
-    <HeaderAndTabsContainer $tabBarHeight={tabBarHeight}>
+    <>
       <SubjectsHeader bgcolor="var(--ion-color-primary-tint)">
         Level
         <SubjectTabs
@@ -94,14 +100,16 @@ const SubjectsContent = ({ level, setLevel }: SubjectsContentProps) => {
           setSelectedIndex={setPage}
         />
       </SubjectsHeader>
-      <Paginator
-        showNavigationButtons={false}
-        pageArr={levelPages}
-        currentPage={currentPage}
-        direction={direction}
-        setCurrentPage={setCurrentPage}
-      />
-    </HeaderAndTabsContainer>
+      <SubjectsPageContainer $tabBarHeight={tabBarHeight}>
+        <Paginator
+          showNavigationButtons={false}
+          pageArr={levelPages}
+          currentPage={currentPage}
+          direction={direction}
+          setCurrentPage={setCurrentPage}
+        />
+      </SubjectsPageContainer>
+    </>
   );
 };
 


### PR DESCRIPTION
- Scroll restoration for subject details page, home page, search page, and for levels list on subjects page
- Search box always displays on page now even when scrolled all the way down
- Considered partial support because subjects page, subject info bottom sheet, and probably some other areas don't have scroll restoration yet