### PR TITLE
Assignment Settings Loading and Error Page State and "Do More Reviews" Button Fix

### DIFF
--- a/src/components/AssignmentSettings/AssignmentSettings.tsx
+++ b/src/components/AssignmentSettings/AssignmentSettings.tsx
@@ -163,7 +163,7 @@ function AssignmentSettings({ assignmentData }: AssignmentSettingsProps) {
         toastType: "error",
         title: "No Subjects Found",
         content:
-          "Unabled to start session. No subjects were returned from the server, oh no!",
+          "Unable to start session. No subjects were returned from the server, oh no!",
         timeout: 10000,
       });
       return;

--- a/src/components/AssignmentSettings/AssignmentSettings.tsx
+++ b/src/components/AssignmentSettings/AssignmentSettings.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { useAssignmentQueueStore } from "../../stores/useAssignmentQueueStore/useAssignmentQueueStore";
+import useAssignmentQueueStoreFacade from "../../stores/useAssignmentQueueStore/useAssignmentQueueStore.facade";
 import useQueueStoreFacade from "../../stores/useQueueStore/useQueueStore.facade";
 import useAssignmentSubmitStoreFacade from "../../stores/useAssignmentSubmitStore/useAssignmentSubmitStore.facade";
 import { useAssignmentSettingsCtxStore } from "../../stores/useAssignmentSettingsCtxStore/useAssignmentSettingsCtxStore";
@@ -44,14 +44,10 @@ function AssignmentSettings({ assignmentData }: AssignmentSettingsProps) {
   const [selectedTabKey, setSelectedTabKey] = useState<string>("basic");
 
   const { resetAll: resetQueueStore } = useQueueStoreFacade();
-  const resetAssignmentQueue = useAssignmentQueueStore(
-    (state) => state.resetAll
-  );
+  const { setAssignmentQueueData, resetAll: resetAssignmentQueue } =
+    useAssignmentQueueStoreFacade();
   const { resetAll: resetAssignmentSubmit, setShouldBatchSubmit } =
     useAssignmentSubmitStoreFacade();
-  const setAssignmentQueueData = useAssignmentQueueStore(
-    (state) => state.setAssignmentQueueData
-  );
   const [isLoading, setIsLoading] = useState(true);
 
   const subjIDs = getSubjIDsFromAssignments(assignmentData);

--- a/src/components/AssignmentSettings/AssignmentSettings.tsx
+++ b/src/components/AssignmentSettings/AssignmentSettings.tsx
@@ -27,6 +27,8 @@ import BasicAssignmentSettings from "../BasicAssignmentSettings";
 import AdvancedAssignmentSettings from "../AdvancedAssignmentSettings";
 import StartSessionButton from "../StartSessionButton";
 import Tabs from "../Tabs";
+import LoadingDots from "../LoadingDots";
+import { FixedCenterContainer } from "../../styles/BaseStyledComponents";
 
 export type AssignmentSettingsProps = {
   assignmentData: Assignment[];
@@ -60,6 +62,13 @@ function AssignmentSettings({ assignmentData }: AssignmentSettingsProps) {
   const { data: studyMaterialsData, isLoading: studyMaterialsLoading } =
     useStudyMaterialsBySubjIDs(subjIDs, queriesEnabled);
 
+  // resetting states in case some weirdness occurred and there's a review session or lesson quiz in progress
+  useEffect(() => {
+    resetQueueStore();
+    resetAssignmentQueue();
+    resetAssignmentSubmit();
+  }, []);
+
   useEffect(() => {
     if (
       !subjectsLoading &&
@@ -69,8 +78,16 @@ function AssignmentSettings({ assignmentData }: AssignmentSettingsProps) {
       studyMaterialsData !== undefined
     ) {
       setIsLoading(false);
+    } else {
+      setIsLoading(true);
     }
-  }, [subjectsLoading, studyMaterialsLoading]);
+  }, [
+    subjectsLoading,
+    studyMaterialsLoading,
+    subjIDs,
+    subjectsData,
+    studyMaterialsData,
+  ]);
 
   // needs to be string type for selector, so subject IDs will be converted to number on submit
   const [selectedAdvancedSubjIDs, setSelectedAdvancedSubjIDs] = useState<
@@ -170,10 +187,6 @@ function AssignmentSettings({ assignmentData }: AssignmentSettingsProps) {
         ? submitWithBasicSettings(subjectsData)
         : submitWithAdvancedSettings();
 
-    // ending in case some weirdness occurred and there's a review session or lesson quiz in progress
-    resetQueueStore();
-    resetAssignmentQueue();
-    resetAssignmentSubmit();
     setIsLoading(true);
 
     // getting data for assignment queue
@@ -204,7 +217,7 @@ function AssignmentSettings({ assignmentData }: AssignmentSettingsProps) {
 
   return (
     <>
-      {!isLoading && (
+      {!isLoading ? (
         <>
           <Tabs
             id="assignmentSettingsTabs"
@@ -249,6 +262,10 @@ function AssignmentSettings({ assignmentData }: AssignmentSettingsProps) {
             buttonType={settingsType}
           />
         </>
+      ) : (
+        <FixedCenterContainer>
+          <LoadingDots />
+        </FixedCenterContainer>
       )}
     </>
   );

--- a/src/components/AssignmentSettings/AssignmentSettings.tsx
+++ b/src/components/AssignmentSettings/AssignmentSettings.tsx
@@ -55,12 +55,16 @@ function AssignmentSettings({ assignmentData }: AssignmentSettingsProps) {
   const subjIDs = getSubjIDsFromAssignments(assignmentData);
   const queriesEnabled = subjIDs.length !== 0;
 
-  const { data: subjectsData, isLoading: subjectsLoading } = useSubjectsByIDs(
-    subjIDs,
-    queriesEnabled
-  );
-  const { data: studyMaterialsData, isLoading: studyMaterialsLoading } =
-    useStudyMaterialsBySubjIDs(subjIDs, queriesEnabled);
+  const {
+    data: subjectsData,
+    isLoading: subjectsLoading,
+    error: subjectsDataErr,
+  } = useSubjectsByIDs(subjIDs, queriesEnabled);
+  const {
+    data: studyMaterialsData,
+    isLoading: studyMaterialsLoading,
+    error: studyMaterialsDataErr,
+  } = useStudyMaterialsBySubjIDs(subjIDs, queriesEnabled);
 
   // resetting states in case some weirdness occurred and there's a review session or lesson quiz in progress
   useEffect(() => {
@@ -215,9 +219,16 @@ function AssignmentSettings({ assignmentData }: AssignmentSettingsProps) {
     }
   };
 
+  // TODO: display errors in less icky way
   return (
     <>
-      {!isLoading ? (
+      {!subjectsLoading && subjectsDataErr && (
+        <p>{`Error loading subjects data: ${JSON.stringify(subjectsDataErr)}`}</p>
+      )}
+      {!studyMaterialsLoading && studyMaterialsDataErr && (
+        <p>{`Error loading study materials data: ${JSON.stringify(studyMaterialsDataErr)}`}</p>
+      )}
+      {!isLoading && !subjectsDataErr && !studyMaterialsDataErr && (
         <>
           <Tabs
             id="assignmentSettingsTabs"
@@ -262,7 +273,8 @@ function AssignmentSettings({ assignmentData }: AssignmentSettingsProps) {
             buttonType={settingsType}
           />
         </>
-      ) : (
+      )}
+      {isLoading && !subjectsDataErr && !studyMaterialsDataErr && (
         <FixedCenterContainer>
           <LoadingDots />
         </FixedCenterContainer>


### PR DESCRIPTION
- Displaying loading dots on assignment settings page while data is loading 
- Displaying errors if any occur
- Fixes issue with "Do More Reviews" button (seen on review summary page) where "Unable to start session" error toast would appear if user clicked button to start review session too fast
- Replaced accidental use of directly using store with facade version