### PR TITLE
Disallow swiping left to retry if no answer has been submitted

### DIFF
--- a/src/components/AssignmentQueueCards/AssignmentQueueCard.tsx
+++ b/src/components/AssignmentQueueCards/AssignmentQueueCard.tsx
@@ -236,8 +236,9 @@ export const AssignmentQueueCard = ({
     ) {
       attemptToAdvance();
     } else if (
-      info.offset.x < -xOffsetTrigger ||
-      (info.offset.x < -xMinOffset && info.velocity.x < -xMinVelocity)
+      isSubmittingAnswer &&
+      (info.offset.x < -xOffsetTrigger ||
+        (info.offset.x < -xMinOffset && info.velocity.x < -xMinVelocity))
     ) {
       retryTriggered();
     } else {
@@ -259,10 +260,12 @@ export const AssignmentQueueCard = ({
               rotate,
             }}
             drag="x"
-            dragConstraints={{ left: 0, right: 0 }}
+            // Neatest way I found to only allow swiping to the right
+            // but if the user will try to swipe left they will see a very slight rotation
+            dragConstraints={{ left: isSubmittingAnswer ? 0 : 1, right: 0 }}
             onDragEnd={handleDragEnd}
             whileTap={{ cursor: "grabbing" }}
-            dragElastic={0.5}
+            dragElastic={{ left: isSubmittingAnswer ? 0.5 : 0, right: 0.5 }}
           >
             <AssignmentCharAndType
               currentReviewItem={currentReviewItem}


### PR DESCRIPTION
Hello!
Was looking through the code to see if I could fix some of the bugs that I've been seeing, and noticed that you can try to retry a card even though it hasn't been submitted.
The code  makes sense for the keyboard shortcuts in the web version, but there is no need to allow the user to swipe to retry in this case.
This is my first time working in typescript / react, so feedback would be appreciated!