### PR TITLE
Disallow swiping left to retry if no answer has been submitted

### DIFF
--- a/src/components/AssignmentQueueCards/AssignmentQueueCard.tsx
+++ b/src/components/AssignmentQueueCards/AssignmentQueueCard.tsx
@@ -236,8 +236,9 @@ export const AssignmentQueueCard = ({
     ) {
       attemptToAdvance();
     } else if (
-      info.offset.x < -xOffsetTrigger ||
-      (info.offset.x < -xMinOffset && info.velocity.x < -xMinVelocity)
+      isSubmittingAnswer &&
+      (info.offset.x < -xOffsetTrigger ||
+        (info.offset.x < -xMinOffset && info.velocity.x < -xMinVelocity))
     ) {
       retryTriggered();
     } else {
@@ -259,10 +260,12 @@ export const AssignmentQueueCard = ({
               rotate,
             }}
             drag="x"
-            dragConstraints={{ left: 0, right: 0 }}
+            // Neatest way I found to only allow swiping to the right
+            // but if the user will try to swipe left they will see a very slight rotation
+            dragConstraints={{ left: isSubmittingAnswer ? 0 : 1, right: 0 }}
             onDragEnd={handleDragEnd}
             whileTap={{ cursor: "grabbing" }}
-            dragElastic={0.5}
+            dragElastic={{ left: isSubmittingAnswer ? 0.5 : 0, right: 0.5 }}
           >
             <AssignmentCharAndType
               currentReviewItem={currentReviewItem}


### PR DESCRIPTION
Hey!
I noticed that you can attempt to retry a card before it has been submitted.
I understand that the logic needs to be there in case someone uses the keyboard shortcuts, but I don't think we need to allow users to try to swipe to retry before submitting.
Also, this is the first time I have worked on a Web / Mobile application, so feedback would be greatly appreciated!