### PR TITLE
Add Development information to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ The app should then be available at http://localhost:5173/
 
 #### iOS and Android Simulators (with Hot Reload)
 
+Make sure to install Corvoda's required dependencies for [iOS](https://cordova.apache.org/docs/en/11.x/guide/platforms/ios/index.html)/[Android](https://cordova.apache.org/docs/en/11.x/guide/platforms/android/) before running the following commands.
 If below doesn't work, check that network URL after displayed after running `npm run start-exposed` matches the URL in the _capacitor.config.ts_ file
 
 Start server in one terminal:
@@ -186,6 +187,10 @@ You can then select the type of iOS device you'd like to use as a simulator
 
 ```bash
 npm run android-live-reload
+
+# If any errors occur, set the following environment variables and try again, or run the app using Android Studio
+export JAVA_HOME=/path/to/android-studio/jbr
+export ANDROID_SDK_ROOT=/path/to/Android/Sdk
 ```
 
 ##### To view debug info (inspect elements, view console output)


### PR DESCRIPTION
Hello!
Hakubun has inspired me to finally start contributing to open-source projects, and try out a new field of programming.
In this PR I add a little bit of information to the development section in the README, that would have saved me time starting out, and  which will hopefully make it easier for new contributors to join.

Also, I saw that you have a stale branch that adds a bit more information about the app's architecture to the README, and I think it would be great if you also merged that branch.