### PR TITLE
"End Session/Quiz" Dialog Confirmation Appearing on Summary Pages

### DIFF
--- a/src/components/LeaveSessionPrompt/LeaveSessionPrompt.tsx
+++ b/src/components/LeaveSessionPrompt/LeaveSessionPrompt.tsx
@@ -13,13 +13,14 @@ const blockUserLeavingPage = ({
   currentLocation,
   nextLocation,
 }: ShouldBlockParams) => {
-  // allowing user to view subjects pages during reviews and to review summary page
-  const subjDetailsRegex = new RegExp("/subjects/*");
   if (
-    subjDetailsRegex.test(nextLocation.pathname) ||
-    nextLocation.pathname === "/reviews/summary" ||
-    nextLocation.pathname === "/lessons/quiz" ||
-    nextLocation.pathname === "/lessons/summary"
+    // allowing user to view subjects pages during reviews and to review summary page
+    nextLocation.pathname.startsWith("/subjects") ||
+    nextLocation.pathname.endsWith("/session") ||
+    // Don't block redirection to / from summaries
+    currentLocation.pathname.endsWith("/summary") ||
+    nextLocation.pathname.endsWith("/summary") ||
+    nextLocation.pathname.endsWith("/quiz")
   ) {
     return false;
   }

--- a/src/components/LeaveSessionPrompt/LeaveSessionPrompt.tsx
+++ b/src/components/LeaveSessionPrompt/LeaveSessionPrompt.tsx
@@ -13,18 +13,12 @@ const blockUserLeavingPage = ({
   currentLocation,
   nextLocation,
 }: ShouldBlockParams) => {
-  if (
-    // allowing user to view subjects pages during reviews and to review summary page
-    nextLocation.pathname.startsWith("/subjects") ||
-    nextLocation.pathname.endsWith("/session") ||
-    // Don't block redirection to / from summaries
-    currentLocation.pathname.endsWith("/summary") ||
-    nextLocation.pathname.endsWith("/summary") ||
-    nextLocation.pathname.endsWith("/quiz")
-  ) {
-    return false;
-  }
-  return true;
+  // Only try to block if moving from lessons / reviews directly to the home screen without wrapping up
+  return (
+    (currentLocation.pathname.endsWith("/session") ||
+      currentLocation.pathname == "/lessons/quiz") &&
+    nextLocation.pathname == "/"
+  );
 };
 
 type Props = Omit<


### PR DESCRIPTION
I noticed that I started to get a popup that blocks me from moving from the summary to the homepage, so I exempted it from the blocking function. I also replaced the regex with  `startsWith` / `endsWith` to make the code a bit clearer and faster.
Finally, I reduced the animation time of the wrapping up popup as I felt that it was a bit too long.