### PR TITLE
Can't Add Alternative Meaning

### DIFF
--- a/src/services/MiscService/MiscService.ts
+++ b/src/services/MiscService/MiscService.ts
@@ -167,8 +167,8 @@ export const getPopoverStyles = (messageType: PopoverMessageType) => {
 export const constructStudyMaterialData = ({
   subject_id,
   meaning_synonyms = [],
-  meaning_note = null,
-  reading_note = null,
+  meaning_note,
+  reading_note,
 }: StudyMaterialPostDataWithID) => {
   return {
     study_material: {


### PR DESCRIPTION
Fixes a bug where couldn't add an alt meaning for vocab due to defaulting properties to `null` instead of `undefined`