### PR TITLE
Strip common sentence endings

### DIFF
--- a/src/components/AssignmentQueueCards/AssignmentQueueCard.tsx
+++ b/src/components/AssignmentQueueCards/AssignmentQueueCard.tsx
@@ -163,7 +163,7 @@ export const AssignmentQueueCard = ({
   }, []);
 
   const retryTriggered = () => {
-    const strippedUserAnswer = userAnswer.trim();
+    const strippedUserAnswer = userAnswer.trim().replace(/[.!?]/g, "");;
 
     if (isSubmittingAnswer) {
       controls.start("retry");

--- a/src/components/AssignmentQueueCards/AssignmentQueueCard.tsx
+++ b/src/components/AssignmentQueueCards/AssignmentQueueCard.tsx
@@ -163,7 +163,7 @@ export const AssignmentQueueCard = ({
   }, []);
 
   const retryTriggered = () => {
-    const strippedUserAnswer = userAnswer.trim().replace(/[.!?]/g, "");;
+    const strippedUserAnswer = userAnswer.trim().replace(/[.!?]/g, "");
 
     if (isSubmittingAnswer) {
       controls.start("retry");


### PR DESCRIPTION
Sometimes with certain keyboards on android a character will be entered at the end of a word with predictive text 

This PR strips some common endings out (.?!) so that this will not happen. 

A better solution might be to strip all non alphanumeric characters, but there are some exceptions that may be valid (direct kana input, spaces, hyphens) so I went with this approach which will probably be good enough for 90% of scenarios